### PR TITLE
Add sbt-daffodil plugin

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,158 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: CI
+
+# Run CI when pushing a commit to main or creating a pull request or
+# adding another commit to a pull request or reopening a pull request.
+
+on:
+  push:
+    branches-ignore: [ 'dependabot/**' ]
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+# Cancel CI runs in progress when a pull request is updated.
+concurrency:
+  group: ${{ github.head_ref || ((github.ref_name != 'main' && github.ref_name) || github.run_id) }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+
+  # Build Plugin and run tests
+
+  check:
+    name: Java ${{ matrix.java_version }}, Scala ${{ matrix.scala_version }}, ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        java_distribution: [ temurin ]
+        java_version: [ 8, 11, 17 ]
+        scala_version: [ 2.12.18 ]
+        os: [ ubuntu-22.04, windows-2022, macos-12 ]
+        exclude:
+          # only run macos on java 17
+          - os: macos-12
+            java_version: 8
+          - os: macos-12
+            java_version: 11
+        include:
+          - shell: bash
+          - os: windows-2022
+            shell: msys2 {0}
+
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: ${{ matrix.shell }}
+    env:
+      SBT: sbt -J-Xms1024m -J-Xmx5120m -J-XX:ReservedCodeCacheSize=512m -J-XX:MaxMetaspaceSize=1024m ++${{ matrix.scala_version }}
+
+    steps:
+
+      ############################################################
+      # Setup
+      ############################################################
+
+      - name: Check out Repository
+        uses: actions/checkout@v4.1.1
+
+      - name: Setup Java
+        uses: actions/setup-java@v4.0.0
+        with:
+          distribution: ${{ matrix.java_distribution }}
+          java-version: ${{ matrix.java_version }}
+          cache: sbt
+
+      - name: Install Dependencies (Windows)
+        if: runner.os == 'Windows'
+        uses: msys2/setup-msys2@v2
+        with:
+          path-type: inherit
+
+      ############################################################
+      # Build
+      ############################################################
+
+      - name: Compile
+        run: $SBT compile
+
+      ############################################################
+      # Check
+      ############################################################
+
+      - name: Run Scripted Tests
+        run: $SBT scripted
+
+  # Lint checks that do not require compilation
+  lint:
+    name: Lint Checks
+    strategy:
+      fail-fast: false
+      matrix:
+        java_distribution: [ temurin ]
+        java_version: [ 17 ]
+        scala_version: [ 2.12.18 ]
+        os: [ ubuntu-22.04 ]
+    runs-on: ${{ matrix.os }}
+    env:
+      SBT: sbt -J-Xms1024m -J-Xmx5120m -J-XX:ReservedCodeCacheSize=512m -J-XX:MaxMetaspaceSize=1024m ++${{ matrix.scala_version }}
+    steps:
+
+      ############################################################
+      # Setup
+      ############################################################
+
+      - name: Check out Repository
+        uses: actions/checkout@v4.1.1
+
+      - name: Setup Java
+        uses: actions/setup-java@v4.0.0
+        with:
+          distribution: ${{ matrix.java_distribution }}
+          java-version: ${{ matrix.java_version }}
+          cache: sbt
+
+      ############################################################
+      # Lint checks
+      ############################################################
+
+      - name: Run Rat Check
+        if: success() || failure()
+        run: $SBT ratCheck || (cat target/rat.txt; exit 1)
+
+      - name: Run scalafmt Check
+        if: success() || failure()
+        run: $SBT scalafmtCheckAll scalafmtSbtCheck
+
+
+  # Ensure pull requests only have a single commit
+  single-commit:
+    name: Single Commit Pull Request
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check Single Commit
+        uses: actions/github-script@v7.0.1
+        with:
+          script: |
+            const commits = await github.rest.pulls.listCommits({
+              ...context.repo,
+              pull_number: context.issue.number,
+            });
+            core.info("Number of commits in this pull request: " + commits.data.length);
+            if (commits.data.length > 1) {
+              core.setFailed("If approved with two +1's, squash this pull request into one commit");
+            }

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+.bsp
+target

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# https://scalameta.org/scalafmt/docs/configuration.html#other
+
+align.preset = none
+docstrings.style = keep
+indent.defnSite = 2
+indent.extendSite = 2
+maxColumn = 96
+rewrite.imports.groups = [
+    ["scala\\..*", "java\\..*", "javax\\..*"],
+    ["org\\.apache\\.daffodil\\..*"],
+]
+rewrite.imports.sort = ascii
+rewrite.rules = [
+    AvoidInfix,
+    Imports,
+]
+rewrite.trailingCommas.style = always
+runner.dialect = scala212
+spaces.inImportCurlyBraces = true
+version = 3.7.17

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,5 @@
+Apache Daffodil SBT Plugin
+Copyright 2024 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).

--- a/README.md
+++ b/README.md
@@ -1,0 +1,82 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# Apache Daffodil SBT Plugin
+
+Plugin to run Daffodil on DFDL schema projects.
+
+## Enable
+
+To enable the plugin, add the following to `project/plugins.sbt`:
+
+```scala
+addSbtPlugin("org.apache.daffodil" % "sbt-daffodil" % "<version>")
+```
+
+## Features
+
+### Saved Parsers
+
+This plugin adds the ability to create and publish saved parsers of a schema.
+
+For each saved parser to generate, add an entry to the
+`daffodilPackageBinInfos` setting. This setting is a Seq of 3-tuples made up of
+the resource path to the schema, an optional root element to use in that
+schema, and an optional name that is added to the artifact classifier to
+differentiate multiple saved parsers. If the optional root element is `None`,
+then the first element in the schemas is used. An example of this settings
+supporting two roots looks like this:
+
+```scala
+daffodilPackageBinInfos := Seq(
+  ("/com/example/xsd/mainSchema.dfdl.xsd", Some("record"), None)
+  ("/com/example/xsd/mainSchema.dfdl.xsd", Some("fileOrRecords"), Some("file"))
+)
+```
+
+You must also define which versions of Daffodil to build comptiable saved
+parsers using the `daffodilPackageBinVersions` setting. For example, to build
+saved parsers for Daffodil 3.6.0 and 3.5.0:
+
+```scala
+daffodilPackageBinVersions := Set("3.6.0", "3.5.0")
+```
+
+Then run `sbt packageDaffodilBin` to generate saved parsers in the `target/`
+directory. For example, assuming a schema project with name of "format",
+version set to "1.0", and the above configurations, the task would generate the
+following saved parsers:
+
+```
+target/format-1.0-daffodil350.bin
+target/format-1.0-daffodil360.bin
+target/format-1.0-file-daffodil350.bin
+target/format-1.0-file-daffodil360.bin
+```
+
+Note that the artifact names have the suffix "daffodilXYZ".bin, where XYZ is
+the version of Daffodil the saved parser is compatible with.
+
+The `publish`, `publishLocal`, `publishM2` and related publish tasks are
+modified to automatically build and publish the saved parsers as a new
+artifacts.
+
+# License
+
+Apache Daffodil SBT Plugin is licensed under the [Apache License, v2.0].
+
+[Apache License, v2.0]: https://www.apache.org/licenses/LICENSE-2.0

--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+enablePlugins(SbtPlugin)
+
+name := "sbt-daffodil"
+
+organization := "org.apache.daffodil"
+
+version := "1.0.0-SNAPSHOT"
+
+scalaVersion := "2.12.18"
+
+scalacOptions ++= Seq(
+  "-Ywarn-unused:imports",
+)
+
+// SBT Plugin settings
+
+sbtPlugin := true
+
+crossSbtVersions := Seq("1.8.0")
+
+scriptedLaunchOpts ++= Seq(
+  "-Xmx1024M",
+  "-Dplugin.version=" + version.value,
+)
+
+// Rat check settings
+
+ratExcludes := Seq(
+  file(".git"),
+)
+
+ratFailBinaries := true

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,18 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+sbt.version=1.9.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+addSbtPlugin("org.musigma" % "sbt-rat" % "0.7.0")
+
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")

--- a/src/main/scala/org/apache/daffodil/DaffodilPlugin.scala
+++ b/src/main/scala/org/apache/daffodil/DaffodilPlugin.scala
@@ -1,0 +1,219 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil
+
+import java.io.File
+
+import sbt.Keys._
+import sbt._
+
+object DaffodilPlugin extends AutoPlugin {
+
+  override def trigger = allRequirements
+
+  object autoImport {
+    val daffodilPackageBinInfos = settingKey[Seq[(String, Option[String], Option[String])]](
+      "Sequence of 3-tuple defining the main schema resource, optional root element, and optional name",
+    )
+    val daffodilPackageBinVersions = settingKey[Set[String]](
+      "Versions of daffodil to create saved parsers for",
+    )
+    val packageDaffodilBin = taskKey[Seq[File]](
+      "Package daffodil saved parsers",
+    )
+  }
+
+  import autoImport._
+
+  /**
+  * Generate a daffodil version specific ivy configuration string by removing everything
+  * except for alphanumeric characters
+   */
+  def ivyConfigName(daffodilVersion: String): String = {
+    "daffodil" + daffodilVersion.replaceAll("[^a-zA-Z0-9]", "")
+  }
+
+  /**
+   * generate an artifact classifier name using the optional name and daffodil version
+   */
+  def classifierName(optName: Option[String], daffodilVersion: String): String = {
+    val cfg = ivyConfigName(daffodilVersion)
+    (optName.toSeq ++ Seq(cfg)).mkString("-")
+  }
+
+  override lazy val projectSettings: Seq[Setting[_]] = Seq(
+    /**
+     * Default to building no saved parsers and supporting no versions of daffodil
+     */
+    daffodilPackageBinInfos := Seq(),
+    daffodilPackageBinVersions := Set(),
+
+    /**
+     * define and configure a custom Ivy configuration with dependencies to the Daffodil
+     * versions we need, getting us easy access to the Daffodil jars and its dependencies
+     */
+    ivyConfigurations ++= daffodilPackageBinVersions.value.map { daffodilVersion =>
+      val cfg = ivyConfigName(daffodilVersion)
+      Configuration.of(cfg.capitalize, cfg)
+    }.toSeq,
+    libraryDependencies ++= {
+      daffodilPackageBinVersions.value.flatMap { daffodilVersion =>
+        val cfg = ivyConfigName(daffodilVersion)
+        val dafDep = "org.apache.daffodil" %% "daffodil-japi" % daffodilVersion % cfg
+        // logging backends used to hide warnings about missing backends, Daffodil won't
+        // actually output logs that we care about, so this doesn't really matter
+        val logDep = if (SemanticSelector(">=3.5.0").matches(VersionNumber(daffodilVersion))) {
+          "org.slf4j" % "slf4j-nop" % "2.0.9" % cfg
+        } else {
+          "org.apache.logging.log4j" % "log4j-core" % "2.20.0" % cfg
+        }
+        Seq(dafDep, logDep)
+      }.toSeq
+    },
+
+    /**
+     * define the artifacts and the packageDaffodilXyzBin task that creates the artifacts
+     */
+    packageDaffodilBin / artifacts := {
+      daffodilPackageBinVersions.value.flatMap { daffodilVersion =>
+        daffodilPackageBinInfos.value.map { case (_, _, optName) =>
+          // each artifact has the same name as the jar, in the "parser" type, "bin" extension,
+          // and daffodil version specific classifier. If optName is provided, it is prepended
+          // to the classifier separated by a hyphen. Note that publishing as maven style will
+          // only use the name, extension, and classifier
+          val classifier = classifierName(optName, daffodilVersion)
+          Artifact(name.value, "parser", "bin", Some(classifier), Vector(), None)
+        }
+      }.toSeq
+    },
+    packageDaffodilBin := {
+      val logger = streams.value.log
+
+      // this plugin jar includes a forkable main class that does the actual schema compilation
+      // and saving.
+      val pluginJar =
+        new File(this.getClass.getProtectionDomain.getCodeSource.getLocation.toURI)
+
+      // get all dependencies and resources of this project
+      val projectClasspath = (Compile / fullClasspath).value.files
+
+      // need to dropRight to remove the dollar sign in the object name
+      val mainClass = DaffodilSaver.getClass.getCanonicalName.dropRight(1)
+
+      // schema compilation can be expensive, so we only want to fork and compile the schema if
+      // any of the project classpath files change
+      val filesToWatch = projectClasspath.flatMap { f =>
+        if (f.isDirectory) PathFinder(f).allPaths.get else Seq(f)
+      }.toSet
+
+      // the name field is the only thing that makes saved parser artifacts unique. Ensure there
+      // are no duplicates.
+      val groupedClassifiers = daffodilPackageBinInfos.value.groupBy { case (_, _, optName) =>
+        optName
+      }
+      val duplicates = groupedClassifiers.filter { case (k, v) => v.length > 1 }.keySet
+      if (duplicates.size > 0) {
+        val dupsStr = duplicates.mkString(", ")
+        val msg = s"daffodilPackageBinInfos defines duplicate classifiers: $dupsStr"
+        throw new MessageOnlyException(msg)
+      }
+
+      val ivyConfigs = ivyConfigurations.value
+      val classpathTypesVal = (Compile / classpathTypes).value
+      val updateVal = (Compile / update).value
+
+      // FileFunction.cached creates a function that accepts files to watch. If any have
+      // changed, cachedFun will call the function passing in the watched files to regenerate
+      // the ouput. Note that we ignore the input watch files because they are slightly
+      // differnent than what we need to pass to the forked java process, which is just things
+      // that should be on the classpath, and not recurisvely everything inside the classpath
+      val cachedDir = streams.value.cacheDirectory / "daffodilPackageBin"
+      val cachedFun = FileFunction.cached(cachedDir) { (_: Set[File]) =>
+        val targetFiles = daffodilPackageBinVersions.value.flatMap { daffodilVersion =>
+          // get all the Daffodil jars and dependencies for the version of Daffodil associated with
+          // this ivy config
+          val cfg = ivyConfigs.find { _.name == ivyConfigName(daffodilVersion) }.get
+          val daffodilJars = Classpaths.managedJars(cfg, classpathTypesVal, updateVal).files
+
+          // Note that order matters here. The projectClasspath might have daffodil jars on it if
+          // Daffodil is a compile dependency, which could be a different version from the version
+          // of Daffodil we are compiling the schema for. So when we fork Java, daffodilJars must be
+          // on the classpath before projectClasspath jars
+          val classpathFiles = Seq(pluginJar) ++ daffodilJars ++ projectClasspath
+
+          daffodilPackageBinInfos.value.map { case (mainSchema, optRoot, optName) =>
+            val classifier = classifierName(optName, daffodilVersion)
+            val targetFile = target.value / s"${name.value}-${version.value}-${classifier}.bin"
+
+            // extract options out of DAFFODIL_JAVA_OPTS or JAVA_OPTS environment variables.
+            // Note that this doesn't handle escaped spaces or quotes correctly, but that
+            // hopefully shouldn't be needed for specifying java options
+            val envArgs = None
+              .orElse(sys.env.get("DAFFODIL_JAVA_OPTS"))
+              .orElse(sys.env.get("JAVA_OPTS"))
+              .map(_.split("\\s+").toSeq)
+              .getOrElse(Seq.empty)
+
+            val args = envArgs ++ Seq(
+              "-classpath",
+              classpathFiles.mkString(File.pathSeparator),
+              mainClass,
+              mainSchema,
+              targetFile.toString,
+            ) ++ optRoot.toSeq
+
+            logger.info(s"compiling daffodil parser to ${targetFile} ...")
+
+            val forkOpts = ForkOptions()
+              .withOutputStrategy(Some(LoggedOutput(logger)))
+            val ret = Fork.java(forkOpts, args)
+            if (ret != 0) {
+              throw new MessageOnlyException(s"failed to save daffodil parser ${classifier}")
+            }
+            targetFile
+          }
+        }
+        targetFiles.toSet
+      }
+
+      val savedParsers = cachedFun(filesToWatch)
+      savedParsers.toSeq
+    },
+
+    /**
+     * These two settings tell sbt about the artifacts and the task that generates the artifacts
+     * so it knows to generate and publish them when publish/publihLocal/publishM2 is run
+     */
+    artifacts ++= (packageDaffodilBin / artifacts).value,
+    packagedArtifacts := {
+      val arts = (packageDaffodilBin / artifacts).value
+      val files = packageDaffodilBin.value
+
+      // the artifacts and associated files are not necessarily in the same order. For each
+      // artifact, we need to find the associated file (the one that ends with the same
+      // classifier and extension) and update the packagedArtifacts setting with that pair
+      val updatedPackagedArtifacts = arts.foldLeft(packagedArtifacts.value) { case (pa, art) =>
+        val suffix = s"-${art.classifier.get}.${art.extension}"
+        val file = files.find { _.getName.endsWith(suffix) }.get
+        pa.updated(art, file)
+      }
+      updatedPackagedArtifacts
+    },
+  )
+
+}

--- a/src/main/scala/org/apache/daffodil/DaffodilSaver.scala
+++ b/src/main/scala/org/apache/daffodil/DaffodilSaver.scala
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil
+
+import java.io.File
+import java.nio.channels.FileChannel
+import java.nio.channels.WritableByteChannel
+import java.nio.file.Paths
+import java.nio.file.StandardOpenOption
+import scala.collection.JavaConverters._
+
+// We need a special customized classpath, and the easiest way to do that within SBT is by
+// forking. But the only thing that can save a parser via forking is the Daffodil CLI, which we
+// do not publish. So instead we create this class that has a static main that we can fork to
+// compile and save schemas using the version of Daffodil that is on the classpath. Note that it
+// also uses reflection so that it is not tied to any specific version of Daffodil. This is
+// fragile, but the Jave API is pretty set in stone at this point, so this reflection shouldn't
+// break.
+object DaffodilSaver {
+
+  /**
+   * Usage: daffodilReflectionSave <schemaFile> <outputFile> [root]
+   */
+  def main(args: Array[String]): Unit = {
+
+    val schemaFile = new File(this.getClass.getResource(args(0)).toURI)
+    val output = FileChannel.open(
+      Paths.get(args(1)),
+      StandardOpenOption.CREATE,
+      StandardOpenOption.WRITE,
+    )
+    val root = if (args.length > 2) args(2) else null
+
+    // parameter types
+    val cFile = classOf[File]
+    val cString = classOf[String]
+    val cWritableByteChannel = classOf[WritableByteChannel]
+
+    // get the Compiler, ProcessorFactory, and DataProcessor classes and the functions we need
+    // to invoke on those classes. Note that we use JAPI because its easier to use via
+    // reflection than the Scala API and it is much smaller and easier to use then the lib API
+    val daffodilClass = Class.forName("org.apache.daffodil.japi.Daffodil")
+    val daffodilCompiler = daffodilClass.getMethod("compiler")
+
+    val compilerClass = Class.forName("org.apache.daffodil.japi.Compiler")
+    val compilerCompileFile = compilerClass.getMethod("compileFile", cFile, cString, cString)
+
+    val processorFactoryClass = Class.forName("org.apache.daffodil.japi.ProcessorFactory")
+    val processorFactoryIsError = processorFactoryClass.getMethod("isError")
+    val processorFactoryOnPath = processorFactoryClass.getMethod("onPath", cString)
+    val processorFactoryGetDiagnostics = processorFactoryClass.getMethod("getDiagnostics")
+
+    val dataProcessorClass = Class.forName("org.apache.daffodil.japi.DataProcessor")
+    val dataProcessorIsError = dataProcessorClass.getMethod("isError")
+    val dataProcessorSave = dataProcessorClass.getMethod("save", cWritableByteChannel)
+    val dataProcessorGetDiagnostics = processorFactoryClass.getMethod("getDiagnostics")
+
+    val diagnosticClass = Class.forName("org.apache.daffodil.japi.Diagnostic")
+    val diagnosticIsError = diagnosticClass.getMethod("isError")
+    val diagnosticToString = diagnosticClass.getMethod("toString")
+
+    def printDiagnostics(diags: java.util.List[Object]): Unit = {
+      diags.asScala.foreach { d =>
+        // val msg = d.toString
+        val msg = diagnosticToString.invoke(d).asInstanceOf[String]
+        // val isError = d.isError
+        val isError = diagnosticIsError.invoke(d).asInstanceOf[Boolean]
+        val level = if (isError) "error" else "warning"
+        System.err.println(s"[$level] $msg")
+      }
+    }
+
+    // val compiler = Daffodil.compiler()
+    val compiler = daffodilCompiler.invoke(null)
+
+    // val processorFactory = compiler.compileFile(schemaFile, root, None)
+    val processorFactory = compilerCompileFile
+      .invoke(compiler, schemaFile, root, null)
+
+    // val processorFactoryDiags = processorFactory.getDiagnostics()
+    val processorFactoryDiags = processorFactoryGetDiagnostics
+      .invoke(processorFactory)
+      .asInstanceOf[java.util.List[Object]]
+    printDiagnostics(processorFactoryDiags)
+
+    // if (processorFactory.isError) System.exit(1)
+    if (processorFactoryIsError.invoke(processorFactory).asInstanceOf[Boolean]) System.exit(1)
+
+    // val dataProcessor= processorFactory.onPath("/")
+    val dataProcessor = processorFactoryOnPath.invoke(processorFactory, "/")
+
+    // val dataProcessorDiags = dataProcessor.getDiagnostics()
+    val dataProcessorDiags = dataProcessorGetDiagnostics
+      .invoke(dataProcessor)
+      .asInstanceOf[java.util.List[Object]]
+    printDiagnostics(dataProcessorDiags)
+
+    // if (dataProcessor.isError) System.exit(1)
+    if (dataProcessorIsError.invoke(dataProcessor).asInstanceOf[Boolean]) System.exit(1)
+
+    // dataProcessor.save(output)
+    dataProcessorSave.invoke(dataProcessor, output)
+
+    System.exit(0)
+  }
+
+}

--- a/src/sbt-test/sbt-daffodil/saved-parsers-01/build.sbt
+++ b/src/sbt-test/sbt-daffodil/saved-parsers-01/build.sbt
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+version := "0.1"
+
+name := "test"
+
+organization := "com.example"
+
+crossPaths := false
+
+daffodilPackageBinInfos := Seq(
+  ("/test.dfdl.xsd", None, None),
+  ("/test.dfdl.xsd", Some("test02"), Some("two")),
+)
+
+daffodilPackageBinVersions := Set("3.6.0", "3.5.0")
+

--- a/src/sbt-test/sbt-daffodil/saved-parsers-01/project/build.properties
+++ b/src/sbt-test/sbt-daffodil/saved-parsers-01/project/build.properties
@@ -1,0 +1,18 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+sbt.version=1.9.8

--- a/src/sbt-test/sbt-daffodil/saved-parsers-01/project/plugins.sbt
+++ b/src/sbt-test/sbt-daffodil/saved-parsers-01/project/plugins.sbt
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+addSbtPlugin("org.apache.daffodil" % "sbt-daffodil" % sys.props("plugin.version"))

--- a/src/sbt-test/sbt-daffodil/saved-parsers-01/src/main/resources/test.dfdl.xsd
+++ b/src/sbt-test/sbt-daffodil/saved-parsers-01/src/main/resources/test.dfdl.xsd
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<schema
+  xmlns="http://www.w3.org/2001/XMLSchema" 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:ex="http://example.com"
+  targetNamespace="http://example.com"
+  elementFormDefault="unqualified">
+
+  <include schemaLocation="/org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+
+  <annotation>
+    <appinfo source="http://www.ogf.org/dfdl/">
+      <dfdl:format ref="ex:GeneralFormat" />
+    </appinfo>
+  </annotation>
+
+  <element name="test01" type="xs:string" dfdl:lengthKind="delimited" />
+
+  <element name="test02" type="xs:string" dfdl:lengthKind="delimited" />
+
+</schema>

--- a/src/sbt-test/sbt-daffodil/saved-parsers-01/test
+++ b/src/sbt-test/sbt-daffodil/saved-parsers-01/test
@@ -1,0 +1,31 @@
+## Licensed to the Apache Software Foundation (ASF) under one
+## or more contributor license agreements.  See the NOTICE file
+## distributed with this work for additional information
+## regarding copyright ownership.  The ASF licenses this file
+## to you under the Apache License, Version 2.0 (the
+## "License"); you may not use this file except in compliance
+## with the License.  You may obtain a copy of the License at
+## 
+##  http://www.apache.org/licenses/LICENSE-2.0
+## 
+## Unless required by applicable law or agreed to in writing,
+## software distributed under the License is distributed on an
+## "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+## KIND, either express or implied.  See the License for the
+## specific language governing permissions and limitations
+## under the License.
+## 
+
+> packageDaffodilBin
+$ exists target/test-0.1-daffodil350.bin
+$ exists target/test-0.1-daffodil360.bin
+$ exists target/test-0.1-two-daffodil350.bin
+$ exists target/test-0.1-two-daffodil360.bin
+
+> set publishTo := Some(Resolver.file("file", new File("target/ivy-publish/")))
+> publish
+$ exists target/ivy-publish/com/example/test/0.1/test-0.1.jar
+$ exists target/ivy-publish/com/example/test/0.1/test-0.1-daffodil350.bin
+$ exists target/ivy-publish/com/example/test/0.1/test-0.1-daffodil360.bin
+$ exists target/ivy-publish/com/example/test/0.1/test-0.1-two-daffodil350.bin
+$ exists target/ivy-publish/com/example/test/0.1/test-0.1-two-daffodil360.bin


### PR DESCRIPTION
- Functionality includes the ability to create saved parsres using the packageDaffodilBin task and related settings
- Adds a single "scripted" test to ensure the task works and publishes artifacts correctly
- Configured GitHub actions to compile and run scripted tests, and lint/rat checks copied from Daffodil