### PR TITLE
Configure common settings for DFDL schema project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 
 .bsp
 target
+src/sbt-test/**/build.properties

--- a/README.md
+++ b/README.md
@@ -29,6 +29,18 @@ addSbtPlugin("org.apache.daffodil" % "sbt-daffodil" % "<version>")
 
 ## Features
 
+### Common Settings
+
+This plugin configures a number of SBT settings to have better defaults for
+DFDL schema projects. This includes setting dependencies for testing (e.g.
+daffodil-tdml-processor, junit), juint test options, and more. This requires
+that the plugin knows which version of Daffodil to use, which is set by adding
+the `daffodilVersion` setting to build.sbt, for example:
+
+```scala
+daffodilVersion := "3.6.0"
+```
+
 ### Saved Parsers
 
 This plugin adds the ability to create and publish saved parsers of a schema.
@@ -53,7 +65,7 @@ parsers using the `daffodilPackageBinVersions` setting. For example, to build
 saved parsers for Daffodil 3.6.0 and 3.5.0:
 
 ```scala
-daffodilPackageBinVersions := Set("3.6.0", "3.5.0")
+daffodilPackageBinVersions := Seq("3.6.0", "3.5.0")
 ```
 
 Then run `sbt packageDaffodilBin` to generate saved parsers in the `target/`
@@ -74,6 +86,13 @@ the version of Daffodil the saved parser is compatible with.
 The `publish`, `publishLocal`, `publishM2` and related publish tasks are
 modified to automatically build and publish the saved parsers as a new
 artifacts.
+
+If used, one may want to use the first value of this setting to configure
+`daffodilVersion`, e.g.:
+
+```scala
+daffodilVersion := daffodilPackageBinVersions.value.head
+```
 
 # License
 

--- a/build.sbt
+++ b/build.sbt
@@ -15,8 +15,6 @@
  * limitations under the License.
  */
 
-enablePlugins(SbtPlugin)
-
 name := "sbt-daffodil"
 
 organization := "org.apache.daffodil"
@@ -31,7 +29,7 @@ scalacOptions ++= Seq(
 
 // SBT Plugin settings
 
-sbtPlugin := true
+enablePlugins(SbtPlugin)
 
 crossSbtVersions := Seq("1.8.0")
 

--- a/src/sbt-test/sbt-daffodil/common-settings-01/build.sbt
+++ b/src/sbt-test/sbt-daffodil/common-settings-01/build.sbt
@@ -21,13 +21,4 @@ name := "test"
 
 organization := "com.example"
 
-crossPaths := false
-
-daffodilPackageBinInfos := Seq(
-  ("/test.dfdl.xsd", None, None),
-  ("/test.dfdl.xsd", Some("test02"), Some("two")),
-)
-
-daffodilPackageBinVersions := Seq("3.6.0", "3.5.0")
-
-daffodilVersion := daffodilPackageBinVersions.value.head
+daffodilVersion := "3.6.0"

--- a/src/sbt-test/sbt-daffodil/common-settings-01/project/plugins.sbt
+++ b/src/sbt-test/sbt-daffodil/common-settings-01/project/plugins.sbt
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+addSbtPlugin("org.apache.daffodil" % "sbt-daffodil" % sys.props("plugin.version"))

--- a/src/sbt-test/sbt-daffodil/common-settings-01/src/main/resources/com/example/test.dfdl.xsd
+++ b/src/sbt-test/sbt-daffodil/common-settings-01/src/main/resources/com/example/test.dfdl.xsd
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<schema
+  xmlns="http://www.w3.org/2001/XMLSchema" 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:ex="http://example.com"
+  targetNamespace="http://example.com"
+  elementFormDefault="unqualified">
+
+  <include schemaLocation="/org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+
+  <annotation>
+    <appinfo source="http://www.ogf.org/dfdl/">
+      <dfdl:format ref="ex:GeneralFormat" />
+    </appinfo>
+  </annotation>
+
+  <element name="test01" type="xs:string" dfdl:lengthKind="delimited" />
+
+</schema>

--- a/src/sbt-test/sbt-daffodil/common-settings-01/src/test/resources/com/example/test.tdml
+++ b/src/sbt-test/sbt-daffodil/common-settings-01/src/test/resources/com/example/test.tdml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<testSuite
+  xmlns="http://www.ibm.com/xmlns/dfdl/testData"
+  xmlns:tdml="http://www.ibm.com/xmlns/dfdl/testData"
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:ex="http://example.com">
+
+  <parserTestCase name="test01" root="test01" model="com/example/test.dfdl.xsd">
+    <document>test data</document>
+    <infoset>
+      <dfdlInfoset>
+        <ex:test01>test data</ex:test01>
+      </dfdlInfoset>
+    </infoset>
+  </parserTestCase>
+  
+</testSuite>

--- a/src/sbt-test/sbt-daffodil/common-settings-01/src/test/scala/com/example/test.scala
+++ b/src/sbt-test/sbt-daffodil/common-settings-01/src/test/scala/com/example/test.scala
@@ -15,4 +15,20 @@
  * limitations under the License.
  */
 
-sbt.version=1.9.8
+package com.example
+
+import org.junit.Test
+import org.apache.daffodil.tdml.Runner
+import org.junit.AfterClass
+
+object TestExample {
+  lazy val runner = Runner("/com/example/", "test.tdml")
+
+  @AfterClass def shutdown: Unit = { runner.reset }
+}
+
+class TestExample {
+  import TestExample._
+
+  @Test def test_test01() { runner.runOneTest("test01") }
+}

--- a/src/sbt-test/sbt-daffodil/common-settings-01/test.script
+++ b/src/sbt-test/sbt-daffodil/common-settings-01/test.script
@@ -1,0 +1,20 @@
+## Licensed to the Apache Software Foundation (ASF) under one
+## or more contributor license agreements.  See the NOTICE file
+## distributed with this work for additional information
+## regarding copyright ownership.  The ASF licenses this file
+## to you under the Apache License, Version 2.0 (the
+## "License"); you may not use this file except in compliance
+## with the License.  You may obtain a copy of the License at
+## 
+##  http://www.apache.org/licenses/LICENSE-2.0
+## 
+## Unless required by applicable law or agreed to in writing,
+## software distributed under the License is distributed on an
+## "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+## KIND, either express or implied.  See the License for the
+## specific language governing permissions and limitations
+## under the License.
+## 
+
+> compile
+> test


### PR DESCRIPTION
- Add new "daffodilVersion" setting, used to specify which version of Daffodil "sbt test" should build and run against. This is used to add dependencies like daffodil-tdml-processor, junit, and loggers if needed
- Set crossPaths to false--schema projects jars do not depend on specific versions of Scala since they just contain resources. This makes it so the _2.12 is not included in jar file names.
- Set testOptions for verbose logging with SBT JUnit interface
- Change daffodilPackageBinVersion from a Set to a Seq. This makes it so order is deterministic and schema projects can do things like:

      daffodilVersion := daffodilPackageBinVersions.head

- Remove sbtPlugin := true setting--that is already set by enabling the SbtPlugin plugin
- Update scripted test to use new settings and remove settings the plugin now provides.
- Ignore project/build.properties in scripted tests--when running scripted tests manually sbt creates these files and we don't want them

Closes #9