### PR TITLE
Support schema projects that build layers and UDFs

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,32 @@ If used, one may want to use the first value of this setting to configure
 daffodilVersion := daffodilPackageBinVersions.value.head
 ```
 
+## Layers and User Defined Functions
+
+If your schema project builds a Daffodil layer or user defined function, then
+set the `daffodilBuildsLayer` or `daffodilBuildsUDF` setting to true,
+respectively. For example:
+
+```scala
+daffodilBuildsLayer := true
+
+daffodilBuildsUDF := true
+```
+
+Setting either of these values to true adds additional dependencies needed to
+build the component.
+
+Note that this also sets the SBT `crossPaths` setting to `true`, which causes
+the Scala version to be included in the jar file name, since layer and UDF jars
+may be implemented in Scala and are specific to the Scala version used to build
+them. However, if your schema project implements layers/UDFs using only Java,
+you can override this in build.sbt and remove the Scala version from the jar
+name, for example:
+
+```scala
+crossPaths := false
+```
+
 ## Flat Directory Layout
 
 Instead of using the standard `src/{main,test}/{scala,resources}/` directory

--- a/src/sbt-test/sbt-daffodil/builds-layer-01/build.sbt
+++ b/src/sbt-test/sbt-daffodil/builds-layer-01/build.sbt
@@ -21,11 +21,6 @@ name := "test"
 
 organization := "com.example"
 
-daffodilPackageBinInfos := Seq(
-  ("/test.dfdl.xsd", None, None),
-  ("/test.dfdl.xsd", Some("test02"), Some("two")),
-)
+daffodilVersion := "3.6.0"
 
-daffodilPackageBinVersions := Seq("3.6.0", "3.5.0")
-
-daffodilVersion := daffodilPackageBinVersions.value.head
+daffodilBuildsLayer := true

--- a/src/sbt-test/sbt-daffodil/builds-layer-01/project/plugins.sbt
+++ b/src/sbt-test/sbt-daffodil/builds-layer-01/project/plugins.sbt
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+addSbtPlugin("org.apache.daffodil" % "sbt-daffodil" % sys.props("plugin.version"))

--- a/src/sbt-test/sbt-daffodil/builds-layer-01/src/main/scala/com/example/layer.scala
+++ b/src/sbt-test/sbt-daffodil/builds-layer-01/src/main/scala/com/example/layer.scala
@@ -15,17 +15,12 @@
  * limitations under the License.
  */
 
-version := "0.1"
+package com.example
 
-name := "test"
+import org.apache.daffodil.runtime1.layers.LayerCompiler
 
-organization := "com.example"
+// this is not a real layer, but the above import will fail to compile if
+// daffodil-runtime1-layers is not on the compile classpath
+class TestLayer {
+}
 
-daffodilPackageBinInfos := Seq(
-  ("/test.dfdl.xsd", None, None),
-  ("/test.dfdl.xsd", Some("test02"), Some("two")),
-)
-
-daffodilPackageBinVersions := Seq("3.6.0", "3.5.0")
-
-daffodilVersion := daffodilPackageBinVersions.value.head

--- a/src/sbt-test/sbt-daffodil/builds-layer-01/test.script
+++ b/src/sbt-test/sbt-daffodil/builds-layer-01/test.script
@@ -1,0 +1,26 @@
+## Licensed to the Apache Software Foundation (ASF) under one
+## or more contributor license agreements.  See the NOTICE file
+## distributed with this work for additional information
+## regarding copyright ownership.  The ASF licenses this file
+## to you under the Apache License, Version 2.0 (the
+## "License"); you may not use this file except in compliance
+## with the License.  You may obtain a copy of the License at
+## 
+##  http://www.apache.org/licenses/LICENSE-2.0
+## 
+## Unless required by applicable law or agreed to in writing,
+## software distributed under the License is distributed on an
+## "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+## KIND, either express or implied.  See the License for the
+## specific language governing permissions and limitations
+## under the License.
+## 
+
+
+# builds jar, with _2.12 in the name beause layers are scala version specific
+> package
+$ exists target/scala-2.12/test_2.12-0.1.jar
+
+# expect compilation to fail without this setting
+> set daffodilBuildsLayer := false
+-> compile

--- a/src/sbt-test/sbt-daffodil/builds-udf-01/build.sbt
+++ b/src/sbt-test/sbt-daffodil/builds-udf-01/build.sbt
@@ -21,11 +21,6 @@ name := "test"
 
 organization := "com.example"
 
-daffodilPackageBinInfos := Seq(
-  ("/test.dfdl.xsd", None, None),
-  ("/test.dfdl.xsd", Some("test02"), Some("two")),
-)
+daffodilVersion := "3.6.0"
 
-daffodilPackageBinVersions := Seq("3.6.0", "3.5.0")
-
-daffodilVersion := daffodilPackageBinVersions.value.head
+daffodilBuildsUDF := true

--- a/src/sbt-test/sbt-daffodil/builds-udf-01/project/plugins.sbt
+++ b/src/sbt-test/sbt-daffodil/builds-udf-01/project/plugins.sbt
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+addSbtPlugin("org.apache.daffodil" % "sbt-daffodil" % sys.props("plugin.version"))

--- a/src/sbt-test/sbt-daffodil/builds-udf-01/src/main/scala/com/example/udf.scala
+++ b/src/sbt-test/sbt-daffodil/builds-udf-01/src/main/scala/com/example/udf.scala
@@ -15,17 +15,12 @@
  * limitations under the License.
  */
 
-version := "0.1"
+package com.example
 
-name := "test"
+import org.apache.daffodil.udf.UserDefinedFunction
 
-organization := "com.example"
+// this is not a real udf, but the above import will fail to compile if daffodil-udf is not on
+// the compile classpath
+class TestUDF {
+}
 
-daffodilPackageBinInfos := Seq(
-  ("/test.dfdl.xsd", None, None),
-  ("/test.dfdl.xsd", Some("test02"), Some("two")),
-)
-
-daffodilPackageBinVersions := Seq("3.6.0", "3.5.0")
-
-daffodilVersion := daffodilPackageBinVersions.value.head

--- a/src/sbt-test/sbt-daffodil/builds-udf-01/test.script
+++ b/src/sbt-test/sbt-daffodil/builds-udf-01/test.script
@@ -1,0 +1,26 @@
+## Licensed to the Apache Software Foundation (ASF) under one
+## or more contributor license agreements.  See the NOTICE file
+## distributed with this work for additional information
+## regarding copyright ownership.  The ASF licenses this file
+## to you under the Apache License, Version 2.0 (the
+## "License"); you may not use this file except in compliance
+## with the License.  You may obtain a copy of the License at
+## 
+##  http://www.apache.org/licenses/LICENSE-2.0
+## 
+## Unless required by applicable law or agreed to in writing,
+## software distributed under the License is distributed on an
+## "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+## KIND, either express or implied.  See the License for the
+## specific language governing permissions and limitations
+## under the License.
+## 
+
+
+# builds jar, with _2.12 in the name beause UDFs are scala version specific
+> package
+$ exists target/scala-2.12/test_2.12-0.1.jar
+
+# expect compilation to fail without this setting
+> set daffodilBuildsUDF := false
+-> compile


### PR DESCRIPTION
- Add daffodilBuildsLayer and daffodilBuildsUDF settings, which if set to true adds dependencies and modifies crossPaths for projects that builds layers and UDFs, respectively. Defaults to false since most projects will not use these.

Closes #11