### PR TITLE
Support using saved parsers in TDML tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,32 @@ If used, one may want to use the first value of this setting to configure
 daffodilVersion := daffodilPackageBinVersions.value.head
 ```
 
+### Saved Parsers in TDML Tests
+
+For schemas that take a long time to compile, it is often convenient to use a
+saved parser created by the `packageDaffodilBin` task in TDML tests. If this
+is the case, set the following:
+
+```scala
+daffodilTdmlUsesPackageBin := true
+```
+
+When set to `true` , running `sbt test` automatically triggers
+`packageDaffodilBin` and puts the resulting saved parsers on the classpath so
+that TDML files can reference them. Note that when referencing saved parsers
+from a TDML file, version numbers and `daffodilXYZ` are excluded--this way TDML
+files do not need to be updated when a version is changed. For example, a TDML
+file using a saved parser created at `target/format-1.0-file-daffodil350.bin`
+is referenced like this:
+
+```xml
+<parserTestCase ... model="/format-file.bin">
+```
+
+Note that only saved parsers for `daffodilVersion` can be referenced. For this
+reason, `daffodilVersion` must also be defined in `daffodilPackageBinVersions`
+if `daffodilTdmlUsesPackageBin` is `true`.
+
 ## Layers and User Defined Functions
 
 If your schema project builds a Daffodil layer or user defined function, then

--- a/src/sbt-test/sbt-daffodil/tdml-saved-parser-01/build.sbt
+++ b/src/sbt-test/sbt-daffodil/tdml-saved-parser-01/build.sbt
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+version := "0.1"
+
+name := "test"
+
+organization := "com.example"
+
+daffodilPackageBinInfos := Seq(
+  ("/com/example/test.dfdl.xsd", None, None),
+  ("/com/example/test.dfdl.xsd", Some("test02"), Some("two")),
+)
+
+daffodilPackageBinVersions := Seq("3.6.0", "3.5.0")
+
+daffodilVersion := daffodilPackageBinVersions.value.head
+
+daffodilTdmlUsesPackageBin := true

--- a/src/sbt-test/sbt-daffodil/tdml-saved-parser-01/project/plugins.sbt
+++ b/src/sbt-test/sbt-daffodil/tdml-saved-parser-01/project/plugins.sbt
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+addSbtPlugin("org.apache.daffodil" % "sbt-daffodil" % sys.props("plugin.version"))

--- a/src/sbt-test/sbt-daffodil/tdml-saved-parser-01/src/main/resources/com/example/test.dfdl.xsd
+++ b/src/sbt-test/sbt-daffodil/tdml-saved-parser-01/src/main/resources/com/example/test.dfdl.xsd
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<schema
+  xmlns="http://www.w3.org/2001/XMLSchema" 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:ex="http://example.com"
+  targetNamespace="http://example.com"
+  elementFormDefault="unqualified">
+
+  <include schemaLocation="/org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+
+  <annotation>
+    <appinfo source="http://www.ogf.org/dfdl/">
+      <dfdl:format ref="ex:GeneralFormat" />
+    </appinfo>
+  </annotation>
+
+  <element name="test01" type="xs:string" dfdl:lengthKind="delimited" />
+
+  <element name="test02" type="xs:string" dfdl:lengthKind="delimited" />
+
+</schema>

--- a/src/sbt-test/sbt-daffodil/tdml-saved-parser-01/src/test/resources/com/example/test.tdml
+++ b/src/sbt-test/sbt-daffodil/tdml-saved-parser-01/src/test/resources/com/example/test.tdml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<testSuite
+  xmlns="http://www.ibm.com/xmlns/dfdl/testData"
+  xmlns:tdml="http://www.ibm.com/xmlns/dfdl/testData"
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/">
+
+  <parserTestCase name="test01" root="test01" model="/test.bin">
+    <document>
+      <documentPart type="text">testing</documentPart>
+    </document>
+    <infoset>
+      <dfdlInfoset>
+        <test01>testing</test01>
+      </dfdlInfoset>
+    </infoset>
+  </parserTestCase>
+
+  <parserTestCase name="test02" root="test02" model="/test-two.bin">
+    <document>
+      <documentPart type="text">testing</documentPart>
+    </document>
+    <infoset>
+      <dfdlInfoset>
+        <test02>testing</test02>
+      </dfdlInfoset>
+    </infoset>
+  </parserTestCase>
+  
+</testSuite>

--- a/src/sbt-test/sbt-daffodil/tdml-saved-parser-01/src/test/scala/com/example/test.scala
+++ b/src/sbt-test/sbt-daffodil/tdml-saved-parser-01/src/test/scala/com/example/test.scala
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example
+
+import org.junit.Test
+import org.apache.daffodil.tdml.Runner
+import org.junit.AfterClass
+
+object TestExample {
+  lazy val runner = Runner("/com/example/", "test.tdml")
+
+  @AfterClass def shutdown: Unit = { runner.reset }
+}
+
+class TestExample {
+  import TestExample._
+
+  @Test def test_test01() { runner.runOneTest("test01") }
+  @Test def test_test02() { runner.runOneTest("test02") }
+}

--- a/src/sbt-test/sbt-daffodil/tdml-saved-parser-01/test.script
+++ b/src/sbt-test/sbt-daffodil/tdml-saved-parser-01/test.script
@@ -1,0 +1,29 @@
+## Licensed to the Apache Software Foundation (ASF) under one
+## or more contributor license agreements.  See the NOTICE file
+## distributed with this work for additional information
+## regarding copyright ownership.  The ASF licenses this file
+## to you under the Apache License, Version 2.0 (the
+## "License"); you may not use this file except in compliance
+## with the License.  You may obtain a copy of the License at
+## 
+##  http://www.apache.org/licenses/LICENSE-2.0
+## 
+## Unless required by applicable law or agreed to in writing,
+## software distributed under the License is distributed on an
+## "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+## KIND, either express or implied.  See the License for the
+## specific language governing permissions and limitations
+## under the License.
+## 
+
+> packageDaffodilBin
+$ exists target/test-0.1-daffodil350.bin
+$ exists target/test-0.1-daffodil360.bin
+$ exists target/test-0.1-two-daffodil350.bin
+$ exists target/test-0.1-two-daffodil360.bin
+
+> Test/dependencyClasspath
+$ must-mirror target/tdmlparsers/test.bin target/test-0.1-daffodil360.bin
+$ must-mirror target/tdmlparsers/test-two.bin target/test-0.1-two-daffodil360.bin
+
+> test


### PR DESCRIPTION
Adds a new setting called daffodilTdmlUsesPackageBin, which if set to true causes the test task to trigger packageDaffodilBin to create saved parsers and put them on the test classpath. This allows TDML tests to reference and use saved parsers instead of re-compiling everytime tests are run.

Closes #18