### PR TITLE
Bump default daffodilVersion to 3.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,11 @@ addSbtPlugin("org.apache.daffodil" % "sbt-daffodil" % "<version>")
 
 This plugin configures a number of SBT settings to have better defaults for
 DFDL schema projects. This includes setting dependencies for testing (e.g.
-daffodil-tdml-processor, junit), juint test options, and more. This requires
-that the plugin knows which version of Daffodil to use, which is set by adding
-the `daffodilVersion` setting to build.sbt, for example:
+daffodil-tdml-processor, junit), juint test options, and more.
+
+By default, this plugin configures the Daffodil dependency to be the latest
+version available at the time of the plugins release, but to pin to a specific
+Daffodil version set the `daffodilVersion` setting in build.sbt, for example:
 
 ```scala
 daffodilVersion := "3.6.0"

--- a/src/main/scala/org/apache/daffodil/DaffodilPlugin.scala
+++ b/src/main/scala/org/apache/daffodil/DaffodilPlugin.scala
@@ -72,7 +72,7 @@ object DaffodilPlugin extends AutoPlugin {
     /**
      * Default Daffodil version
      */
-    daffodilVersion := "3.6.0",
+    daffodilVersion := "3.7.0",
 
     /**
      * Assume schemas do not include layers or UDFs, projects can override these if they do

--- a/src/sbt-test/sbt-daffodil/versions-01/build.sbt
+++ b/src/sbt-test/sbt-daffodil/versions-01/build.sbt
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+version := "0.1"
+
+name := "test"
+
+organization := "com.example"
+
+daffodilPackageBinInfos := Seq(
+  ("/com/example/test.dfdl.xsd", None, None),
+)
+
+daffodilPackageBinVersions := Seq(daffodilVersion.value)

--- a/src/sbt-test/sbt-daffodil/versions-01/project/plugins.sbt
+++ b/src/sbt-test/sbt-daffodil/versions-01/project/plugins.sbt
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+addSbtPlugin("org.apache.daffodil" % "sbt-daffodil" % sys.props("plugin.version"))

--- a/src/sbt-test/sbt-daffodil/versions-01/src/main/resources/com/example/test.dfdl.xsd
+++ b/src/sbt-test/sbt-daffodil/versions-01/src/main/resources/com/example/test.dfdl.xsd
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<schema
+  xmlns="http://www.w3.org/2001/XMLSchema" 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:ex="http://example.com"
+  targetNamespace="http://example.com"
+  elementFormDefault="unqualified">
+
+  <include schemaLocation="/org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+
+  <annotation>
+    <appinfo source="http://www.ogf.org/dfdl/">
+      <dfdl:format ref="ex:GeneralFormat" />
+    </appinfo>
+  </annotation>
+
+  <element name="test01" type="xs:string" dfdl:lengthKind="delimited" />
+
+</schema>

--- a/src/sbt-test/sbt-daffodil/versions-01/src/test/resources/com/example/test.tdml
+++ b/src/sbt-test/sbt-daffodil/versions-01/src/test/resources/com/example/test.tdml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<testSuite
+  xmlns="http://www.ibm.com/xmlns/dfdl/testData"
+  xmlns:tdml="http://www.ibm.com/xmlns/dfdl/testData"
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:ex="http://example.com">
+
+  <parserTestCase name="test01" root="test01" model="/com/example/test.dfdl.xsd">
+    <document>
+      <documentPart type="text">testing</documentPart>
+    </document>
+    <infoset>
+      <dfdlInfoset>
+        <ex:test01>testing</ex:test01>
+      </dfdlInfoset>
+    </infoset>
+  </parserTestCase>
+
+</testSuite>

--- a/src/sbt-test/sbt-daffodil/versions-01/src/test/scala/com/example/test.scala
+++ b/src/sbt-test/sbt-daffodil/versions-01/src/test/scala/com/example/test.scala
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example
+
+import org.junit.Test
+import org.apache.daffodil.tdml.Runner
+import org.junit.AfterClass
+
+object TestExample {
+  lazy val runner = Runner("/com/example/", "test.tdml")
+
+  @AfterClass def shutdown: Unit = { runner.reset }
+}
+
+class TestExample {
+  import TestExample._
+
+  @Test def test_test01() { runner.runOneTest("test01") }
+}

--- a/src/sbt-test/sbt-daffodil/versions-01/test.script
+++ b/src/sbt-test/sbt-daffodil/versions-01/test.script
@@ -1,0 +1,65 @@
+## Licensed to the Apache Software Foundation (ASF) under one
+## or more contributor license agreements.  See the NOTICE file
+## distributed with this work for additional information
+## regarding copyright ownership.  The ASF licenses this file
+## to you under the Apache License, Version 2.0 (the
+## "License"); you may not use this file except in compliance
+## with the License.  You may obtain a copy of the License at
+## 
+##  http://www.apache.org/licenses/LICENSE-2.0
+## 
+## Unless required by applicable law or agreed to in writing,
+## software distributed under the License is distributed on an
+## "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+## KIND, either express or implied.  See the License for the
+## specific language governing permissions and limitations
+## under the License.
+## 
+
+> set daffodilVersion := "3.7.0"
+> packageDaffodilBin
+$ exists target/test-0.1-daffodil370.bin
+> test
+> clean
+
+> set daffodilVersion := "3.6.0"
+> packageDaffodilBin
+$ exists target/test-0.1-daffodil360.bin
+> test
+> clean
+
+> set daffodilVersion := "3.5.0"
+> packageDaffodilBin
+$ exists target/test-0.1-daffodil350.bin
+> test
+> clean
+
+> set daffodilVersion := "3.4.0"
+> packageDaffodilBin
+$ exists target/test-0.1-daffodil340.bin
+> test
+> clean
+
+> set daffodilVersion := "3.3.0"
+> packageDaffodilBin
+$ exists target/test-0.1-daffodil330.bin
+> test
+> clean
+
+> set daffodilVersion := "3.2.0"
+> packageDaffodilBin
+$ exists target/test-0.1-daffodil320.bin
+> test
+> clean
+
+> set daffodilVersion := "3.1.0"
+> packageDaffodilBin
+$ exists target/test-0.1-daffodil310.bin
+> test
+> clean
+
+> set daffodilVersion := "3.0.0"
+> packageDaffodilBin
+$ exists target/test-0.1-daffodil300.bin
+> test
+> clean


### PR DESCRIPTION
- Update readme to make it more clear daffodiLVersion is not required, but can be used to pin to a specific version
- Aadd test to ensure the plugin works with all Daffodil versions 3.0.0 and newer

Closes #22