### PR TITLE
Require plugin to be explicitly enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ To enable the plugin, add the following to `project/plugins.sbt`:
 addSbtPlugin("org.apache.daffodil" % "sbt-daffodil" % "<version>")
 ```
 
+And add the following to `build.sbt`:
+
+```scala
+enablePlugins(DaffodilPlugin)
+```
+
 ## Features
 
 ### Common Settings

--- a/src/main/scala/org/apache/daffodil/DaffodilPlugin.scala
+++ b/src/main/scala/org/apache/daffodil/DaffodilPlugin.scala
@@ -24,8 +24,6 @@ import sbt._
 
 object DaffodilPlugin extends AutoPlugin {
 
-  override def trigger = allRequirements
-
   object autoImport {
     val daffodilPackageBinInfos = settingKey[Seq[(String, Option[String], Option[String])]](
       "Sequence of 3-tuple defining the main schema resource, optional root element, and optional name",

--- a/src/sbt-test/sbt-daffodil/builds-layer-01/build.sbt
+++ b/src/sbt-test/sbt-daffodil/builds-layer-01/build.sbt
@@ -21,6 +21,8 @@ name := "test"
 
 organization := "com.example"
 
+enablePlugins(DaffodilPlugin)
+
 daffodilVersion := "3.6.0"
 
 daffodilBuildsLayer := true

--- a/src/sbt-test/sbt-daffodil/builds-udf-01/build.sbt
+++ b/src/sbt-test/sbt-daffodil/builds-udf-01/build.sbt
@@ -21,6 +21,8 @@ name := "test"
 
 organization := "com.example"
 
+enablePlugins(DaffodilPlugin)
+
 daffodilVersion := "3.6.0"
 
 daffodilBuildsUDF := true

--- a/src/sbt-test/sbt-daffodil/common-settings-01/build.sbt
+++ b/src/sbt-test/sbt-daffodil/common-settings-01/build.sbt
@@ -21,4 +21,6 @@ name := "test"
 
 organization := "com.example"
 
+enablePlugins(DaffodilPlugin)
+
 daffodilVersion := "3.6.0"

--- a/src/sbt-test/sbt-daffodil/flat-layout-01/build.sbt
+++ b/src/sbt-test/sbt-daffodil/flat-layout-01/build.sbt
@@ -21,6 +21,8 @@ name := "test"
 
 organization := "com.example"
 
+enablePlugins(DaffodilPlugin)
+
 daffodilVersion := "3.6.0"
 
 daffodilFlatLayout := true

--- a/src/sbt-test/sbt-daffodil/saved-parsers-01/build.sbt
+++ b/src/sbt-test/sbt-daffodil/saved-parsers-01/build.sbt
@@ -21,6 +21,8 @@ name := "test"
 
 organization := "com.example"
 
+enablePlugins(DaffodilPlugin)
+
 daffodilPackageBinInfos := Seq(
   ("/test.dfdl.xsd", None, None),
   ("/test.dfdl.xsd", Some("test02"), Some("two")),

--- a/src/sbt-test/sbt-daffodil/tdml-saved-parser-01/build.sbt
+++ b/src/sbt-test/sbt-daffodil/tdml-saved-parser-01/build.sbt
@@ -21,6 +21,8 @@ name := "test"
 
 organization := "com.example"
 
+enablePlugins(DaffodilPlugin)
+
 daffodilPackageBinInfos := Seq(
   ("/com/example/test.dfdl.xsd", None, None),
   ("/com/example/test.dfdl.xsd", Some("test02"), Some("two")),

--- a/src/sbt-test/sbt-daffodil/versions-01/build.sbt
+++ b/src/sbt-test/sbt-daffodil/versions-01/build.sbt
@@ -21,6 +21,8 @@ name := "test"
 
 organization := "com.example"
 
+enablePlugins(DaffodilPlugin)
+
 daffodilPackageBinInfos := Seq(
   ("/com/example/test.dfdl.xsd", None, None),
 )


### PR DESCRIPTION
Currently, if this plugin is added to a project with "addSbtPlugin" in plugins.sbt, then it is automatically enabled for all subprojects as well. For projects that are made up of multiple subprojects, some of which might not be DFDL schema projects, this might not be desired since it automatically adds things like test dependencies.

This removes the allRequirements trigger so that it must explicitly enabled by adding enablePlugins(DaffodilPlugin) to the build.sbt file.

This has the added benefit that you can more easily tell a project is a DFDL project by looking at the build.sbt, since often the defaults provided by the plugin are good enough that all that is needed is the "enablePlugins" line.

Additionally, we may want to create plugins in the future that are separate from this one but depend on it and are enabled only if this plugin is enabled (e.g. IBM cross tester, XSAT). SBT provides that capability, but it means this plugin must not be automatically enabled.