### PR TITLE
Add saved parsers to externalDependencyClasspath instead of dependencyClasspath

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,11 @@ Note that only saved parsers for `daffodilVersion` can be referenced. For this
 reason, `daffodilVersion` must also be defined in `daffodilPackageBinVersions`
 if `daffodilTdmlUsesPackageBin` is `true`.
 
+This is implemented using a SBT resource generator which some IDE's, like
+IntelliJ, do not trigger during builds. So you must either run `sbt Test/compile`
+to manually trigger the resource generator, or let SBT handle builds by
+enabling the "Use SBT shell for builds" option.
+
 ### Layers and User Defined Functions
 
 If your schema project builds a Daffodil layer or user defined function, then

--- a/src/sbt-test/sbt-daffodil/tdml-saved-parser-01/test.script
+++ b/src/sbt-test/sbt-daffodil/tdml-saved-parser-01/test.script
@@ -22,8 +22,8 @@ $ exists target/test-0.1-daffodil360.bin
 $ exists target/test-0.1-two-daffodil350.bin
 $ exists target/test-0.1-two-daffodil360.bin
 
-> Test/dependencyClasspath
-$ must-mirror target/tdmlparsers/test.bin target/test-0.1-daffodil360.bin
-$ must-mirror target/tdmlparsers/test-two.bin target/test-0.1-two-daffodil360.bin
+> Test/compile
+$ must-mirror target/test-classes/test.bin target/test-0.1-daffodil360.bin
+$ must-mirror target/test-classes/test-two.bin target/test-0.1-two-daffodil360.bin
 
 > test


### PR DESCRIPTION
When daffodilTdmlUsesPackageBin is true, this plugin builds saved parsers and adds the saved parser directory to the dependencyClasspath setting. However, IntelliJ does not use this setting to build its test classpath, using externalDependencyClasspath instead. This means tests run from IntelliJ cannot find the save parsers and fail.

To support IntelliJ, we add saved parsers to externalDependencyClasspath instead.

Closes #29