### PR TITLE
Add packageDaffodilBin to use config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,17 +59,23 @@ compatible Scala version] if required.
 This plugin adds the ability to create and publish saved parsers of a schema.
 
 For each saved parser to generate, add an entry to the
-`daffodilPackageBinInfos` setting. This setting is a Seq of 3-tuples made up of
-the resource path to the schema, an optional root element to use in that
-schema, and an optional name that is added to the artifact classifier to
-differentiate multiple saved parsers. If the optional root element is `None`,
-then the first element in the schemas is used. An example of this settings
-supporting two roots looks like this:
+`daffodilPackageBinInfos` setting. This setting is a `Seq[DaffodilBinInfo]`,
+where each element in the sequence defines information to create a saved parser
+with the following parameters:
+
+|Name    |Type             |Reqiured | Description |
+|--------|-----------------|---------|-------------|
+|schema  |`String`         |yes      |Resource path to the main schema |
+|root    |`Option[String]` |no       |Root element in the schema. If `None`, uses the first element in the schema |
+|name    |`Option[String]` |no       |If `Some`, includes value in the jar classifier, useful to distinguish saved parsers |
+|config  |`Option[File]`   |no       |Path to a configuration file used during compilation |
+
+An example of this settings supporting two roots looks like this:
 
 ```scala
 daffodilPackageBinInfos := Seq(
-  ("/com/example/xsd/mainSchema.dfdl.xsd", Some("record"), None)
-  ("/com/example/xsd/mainSchema.dfdl.xsd", Some("fileOrRecords"), Some("file"))
+  DaffodilBinInfo("/com/example/xsd/mainSchema.dfdl.xsd", Some("record"))
+  DaffodilBinInfo("/com/example/xsd/mainSchema.dfdl.xsd", Some("fileOfRecords"), Some("file"))
 )
 ```
 

--- a/src/sbt-test/sbt-daffodil/saved-parsers-01/build.sbt
+++ b/src/sbt-test/sbt-daffodil/saved-parsers-01/build.sbt
@@ -24,8 +24,8 @@ organization := "com.example"
 enablePlugins(DaffodilPlugin)
 
 daffodilPackageBinInfos := Seq(
-  ("/test.dfdl.xsd", None, None),
-  ("/test.dfdl.xsd", Some("test02"), Some("two")),
+  DaffodilBinInfo("/test.dfdl.xsd"),
+  DaffodilBinInfo("/test.dfdl.xsd", Some("test02"), Some("two")),
 )
 
 daffodilPackageBinVersions := Seq("3.6.0", "3.5.0")

--- a/src/sbt-test/sbt-daffodil/saved-parsers-02/build.sbt
+++ b/src/sbt-test/sbt-daffodil/saved-parsers-02/build.sbt
@@ -23,13 +23,12 @@ organization := "com.example"
 
 enablePlugins(DaffodilPlugin)
 
+// same as saved-parsers-01 but uses the old tuple syntax
 daffodilPackageBinInfos := Seq(
-  DaffodilBinInfo("/com/example/test.dfdl.xsd"),
-  DaffodilBinInfo("/com/example/test.dfdl.xsd", Some("test02"), Some("two")),
+  ("/test.dfdl.xsd", None, None),
+  ("/test.dfdl.xsd", Some("test02"), Some("two")),
 )
 
 daffodilPackageBinVersions := Seq("3.6.0", "3.5.0")
 
 daffodilVersion := daffodilPackageBinVersions.value.head
-
-daffodilTdmlUsesPackageBin := true

--- a/src/sbt-test/sbt-daffodil/saved-parsers-02/project/plugins.sbt
+++ b/src/sbt-test/sbt-daffodil/saved-parsers-02/project/plugins.sbt
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+addSbtPlugin("org.apache.daffodil" % "sbt-daffodil" % sys.props("plugin.version"))

--- a/src/sbt-test/sbt-daffodil/saved-parsers-02/src/main/resources/test.dfdl.xsd
+++ b/src/sbt-test/sbt-daffodil/saved-parsers-02/src/main/resources/test.dfdl.xsd
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<schema
+  xmlns="http://www.w3.org/2001/XMLSchema" 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:ex="http://example.com"
+  targetNamespace="http://example.com"
+  elementFormDefault="unqualified">
+
+  <include schemaLocation="/org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+
+  <annotation>
+    <appinfo source="http://www.ogf.org/dfdl/">
+      <dfdl:format ref="ex:GeneralFormat" />
+    </appinfo>
+  </annotation>
+
+  <element name="test01" type="xs:string" dfdl:lengthKind="delimited" />
+
+  <element name="test02" type="xs:string" dfdl:lengthKind="delimited" />
+
+</schema>

--- a/src/sbt-test/sbt-daffodil/saved-parsers-02/test.script
+++ b/src/sbt-test/sbt-daffodil/saved-parsers-02/test.script
@@ -1,0 +1,31 @@
+## Licensed to the Apache Software Foundation (ASF) under one
+## or more contributor license agreements.  See the NOTICE file
+## distributed with this work for additional information
+## regarding copyright ownership.  The ASF licenses this file
+## to you under the Apache License, Version 2.0 (the
+## "License"); you may not use this file except in compliance
+## with the License.  You may obtain a copy of the License at
+## 
+##  http://www.apache.org/licenses/LICENSE-2.0
+## 
+## Unless required by applicable law or agreed to in writing,
+## software distributed under the License is distributed on an
+## "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+## KIND, either express or implied.  See the License for the
+## specific language governing permissions and limitations
+## under the License.
+## 
+
+> packageDaffodilBin
+$ exists target/test-0.1-daffodil350.bin
+$ exists target/test-0.1-daffodil360.bin
+$ exists target/test-0.1-two-daffodil350.bin
+$ exists target/test-0.1-two-daffodil360.bin
+
+> set publishTo := Some(Resolver.file("file", new File("target/ivy-publish/")))
+> publish
+$ exists target/ivy-publish/com/example/test/0.1/test-0.1.jar
+$ exists target/ivy-publish/com/example/test/0.1/test-0.1-daffodil350.bin
+$ exists target/ivy-publish/com/example/test/0.1/test-0.1-daffodil360.bin
+$ exists target/ivy-publish/com/example/test/0.1/test-0.1-two-daffodil350.bin
+$ exists target/ivy-publish/com/example/test/0.1/test-0.1-two-daffodil360.bin

--- a/src/sbt-test/sbt-daffodil/saved-parsers-03/build.sbt
+++ b/src/sbt-test/sbt-daffodil/saved-parsers-03/build.sbt
@@ -24,12 +24,10 @@ organization := "com.example"
 enablePlugins(DaffodilPlugin)
 
 daffodilPackageBinInfos := Seq(
-  DaffodilBinInfo("/com/example/test.dfdl.xsd"),
-  DaffodilBinInfo("/com/example/test.dfdl.xsd", Some("test02"), Some("two")),
+  DaffodilBinInfo("/test.dfdl.xsd", config = Some((Compile / resourceDirectory).value / "test.cfg")),
+  DaffodilBinInfo("/test.dfdl.xsd", Some("test02"), Some("two"), config = Some((Compile / resourceDirectory).value / "test.cfg")),
 )
 
 daffodilPackageBinVersions := Seq("3.6.0", "3.5.0")
 
 daffodilVersion := daffodilPackageBinVersions.value.head
-
-daffodilTdmlUsesPackageBin := true

--- a/src/sbt-test/sbt-daffodil/saved-parsers-03/project/plugins.sbt
+++ b/src/sbt-test/sbt-daffodil/saved-parsers-03/project/plugins.sbt
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+addSbtPlugin("org.apache.daffodil" % "sbt-daffodil" % sys.props("plugin.version"))

--- a/src/sbt-test/sbt-daffodil/saved-parsers-03/src/main/resources/test.cfg
+++ b/src/sbt-test/sbt-daffodil/saved-parsers-03/src/main/resources/test.cfg
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<daf:dfdlConfig
+  xmlns:daf="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:ext">
+  <daf:tunables>
+    <daf:suppressSchemaDefinitionWarnings>
+      encodingErrorPolicyError
+      facetExplicitLengthOutOfRange
+      multipleChoiceBranches
+    </daf:suppressSchemaDefinitionWarnings>
+  </daf:tunables>
+</daf:dfdlConfig>

--- a/src/sbt-test/sbt-daffodil/saved-parsers-03/src/main/resources/test.dfdl.xsd
+++ b/src/sbt-test/sbt-daffodil/saved-parsers-03/src/main/resources/test.dfdl.xsd
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<schema
+  xmlns="http://www.w3.org/2001/XMLSchema" 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:ex="http://example.com"
+  targetNamespace="http://example.com"
+  elementFormDefault="unqualified">
+
+  <include schemaLocation="/org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+
+  <annotation>
+    <appinfo source="http://www.ogf.org/dfdl/">
+      <dfdl:format ref="ex:GeneralFormat" />
+    </appinfo>
+  </annotation>
+
+  <element name="test01" type="xs:string" dfdl:lengthKind="delimited" />
+
+  <element name="test02" type="xs:string" dfdl:lengthKind="delimited" />
+
+</schema>

--- a/src/sbt-test/sbt-daffodil/saved-parsers-03/test.script
+++ b/src/sbt-test/sbt-daffodil/saved-parsers-03/test.script
@@ -1,0 +1,23 @@
+## Licensed to the Apache Software Foundation (ASF) under one
+## or more contributor license agreements.  See the NOTICE file
+## distributed with this work for additional information
+## regarding copyright ownership.  The ASF licenses this file
+## to you under the Apache License, Version 2.0 (the
+## "License"); you may not use this file except in compliance
+## with the License.  You may obtain a copy of the License at
+## 
+##  http://www.apache.org/licenses/LICENSE-2.0
+## 
+## Unless required by applicable law or agreed to in writing,
+## software distributed under the License is distributed on an
+## "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+## KIND, either express or implied.  See the License for the
+## specific language governing permissions and limitations
+## under the License.
+## 
+
+> packageDaffodilBin
+$ exists target/test-0.1-daffodil350.bin
+$ exists target/test-0.1-daffodil360.bin
+$ exists target/test-0.1-two-daffodil350.bin
+$ exists target/test-0.1-two-daffodil360.bin

--- a/src/sbt-test/sbt-daffodil/versions-01/build.sbt
+++ b/src/sbt-test/sbt-daffodil/versions-01/build.sbt
@@ -24,7 +24,7 @@ organization := "com.example"
 enablePlugins(DaffodilPlugin)
 
 daffodilPackageBinInfos := Seq(
-  ("/com/example/test.dfdl.xsd", None, None),
+  DaffodilBinInfo("/com/example/test.dfdl.xsd"),
 )
 
 daffodilPackageBinVersions := Seq(daffodilVersion.value)


### PR DESCRIPTION
The daffodilPackageBinInfos setting is changed from a tuple to a new DaffodilBinInfo class that is specific to Daffodil. This makes it easier to allow for optional fields or extend in the future. For backwards compatibilty, an implicit def is added to automatically convert existing 3-tuples to the new type.

A new optional field is added to DaffodilBinInfo to specify a config file which is used during compilation of saved parsers. This currently only supports tunables since config files can only contain tunables and variable bindings, and variable bindings are excluded when saving a parser.

Closes #6