### PR TITLE
Improve error detection and diagnostics

### DIFF
--- a/src/main/scala/org/apache/daffodil/DaffodilPlugin.scala
+++ b/src/main/scala/org/apache/daffodil/DaffodilPlugin.scala
@@ -349,7 +349,8 @@ object DaffodilPlugin extends AutoPlugin {
 
           daffodilPackageBinInfos.value.map { dbi =>
             val classifier = classifierName(dbi.name, daffodilVersion)
-            val targetFile = target.value / s"${name.value}-${version.value}-${classifier}.bin"
+            val targetName = s"${name.value}-${version.value}-${classifier}.bin"
+            val targetFile = target.value / targetName
 
             // extract options out of DAFFODIL_JAVA_OPTS or JAVA_OPTS environment variables.
             // Note that this doesn't handle escaped spaces or quotes correctly, but that
@@ -376,7 +377,7 @@ object DaffodilPlugin extends AutoPlugin {
               .withOutputStrategy(Some(LoggedOutput(logger)))
             val ret = Fork.java(forkOpts, args)
             if (ret != 0) {
-              throw new MessageOnlyException(s"failed to save daffodil parser ${classifier}")
+              throw new MessageOnlyException(s"failed to save daffodil parser: $targetName")
             }
             targetFile
           }

--- a/src/main/scala/org/apache/daffodil/DaffodilSaver.scala
+++ b/src/main/scala/org/apache/daffodil/DaffodilSaver.scala
@@ -40,7 +40,10 @@ object DaffodilSaver {
    */
   def main(args: Array[String]): Unit = {
 
-    if (args.length != 4) System.err.println(s"[error] four arguments are required")
+    assert(
+      args.length == 4,
+      "DaffodilPlugin did not provide the correct number of arguments when forking DaffodilSaver",
+    )
 
     val schemaUrl = this.getClass.getResource(args(0))
     if (schemaUrl == null) {

--- a/src/sbt-test/sbt-daffodil/saved-parsers-04/build.sbt
+++ b/src/sbt-test/sbt-daffodil/saved-parsers-04/build.sbt
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+version := "0.1"
+
+name := "test"
+
+organization := "com.example"
+
+enablePlugins(DaffodilPlugin)
+
+daffodilPackageBinInfos := Seq(
+  DaffodilBinInfo("/does-not-exist.dfdl.xsd")
+)
+
+daffodilPackageBinVersions := Seq(daffodilVersion.value)

--- a/src/sbt-test/sbt-daffodil/saved-parsers-04/project/plugins.sbt
+++ b/src/sbt-test/sbt-daffodil/saved-parsers-04/project/plugins.sbt
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+addSbtPlugin("org.apache.daffodil" % "sbt-daffodil" % sys.props("plugin.version"))

--- a/src/sbt-test/sbt-daffodil/saved-parsers-04/test.script
+++ b/src/sbt-test/sbt-daffodil/saved-parsers-04/test.script
@@ -1,0 +1,19 @@
+## Licensed to the Apache Software Foundation (ASF) under one
+## or more contributor license agreements.  See the NOTICE file
+## distributed with this work for additional information
+## regarding copyright ownership.  The ASF licenses this file
+## to you under the Apache License, Version 2.0 (the
+## "License"); you may not use this file except in compliance
+## with the License.  You may obtain a copy of the License at
+## 
+##  http://www.apache.org/licenses/LICENSE-2.0
+## 
+## Unless required by applicable law or agreed to in writing,
+## software distributed under the License is distributed on an
+## "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+## KIND, either express or implied.  See the License for the
+## specific language governing permissions and limitations
+## under the License.
+## 
+
+-> packageDaffodilBin


### PR DESCRIPTION
- We now detect when a schema resource could not be found and create a helpful error message instead of throwing a NPE
- Change the "failed to save daffodil parser" message to include the full target file name instead of just the classifier--this makes it more clear which parser is failing to compile
- Do not include '[error]' in error messages created by the parser saver. SBT automatically captures stderr and prepends '[error]'
- Make sure to exit(1) if the correct number of arguments aren't provided to the saver.

Close #4