### PR TITLE
Support compiling main schemas found in a jar

### DIFF
--- a/src/sbt-test/sbt-daffodil/saved-parsers-05/build.sbt
+++ b/src/sbt-test/sbt-daffodil/saved-parsers-05/build.sbt
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+version := "0.1"
+
+name := "test"
+
+organization := "com.example"
+
+// tells SBT to build a jar and put it on the classpath instead of putting src/main/resources on
+// the classpath. This means schema resource paths will resolve to a path inside a jar instead
+// of to a file
+exportJars := true
+
+enablePlugins(DaffodilPlugin)
+
+daffodilPackageBinInfos := Seq(
+  DaffodilBinInfo("/test.dfdl.xsd"),
+  DaffodilBinInfo("/test.dfdl.xsd", Some("test02"), Some("two")),
+)
+
+daffodilPackageBinVersions := Seq("3.6.0", "3.5.0")
+
+daffodilVersion := daffodilPackageBinVersions.value.head

--- a/src/sbt-test/sbt-daffodil/saved-parsers-05/project/plugins.sbt
+++ b/src/sbt-test/sbt-daffodil/saved-parsers-05/project/plugins.sbt
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+addSbtPlugin("org.apache.daffodil" % "sbt-daffodil" % sys.props("plugin.version"))

--- a/src/sbt-test/sbt-daffodil/saved-parsers-05/src/main/resources/test.dfdl.xsd
+++ b/src/sbt-test/sbt-daffodil/saved-parsers-05/src/main/resources/test.dfdl.xsd
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<schema
+  xmlns="http://www.w3.org/2001/XMLSchema" 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:ex="http://example.com"
+  targetNamespace="http://example.com"
+  elementFormDefault="unqualified">
+
+  <include schemaLocation="/org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+
+  <annotation>
+    <appinfo source="http://www.ogf.org/dfdl/">
+      <dfdl:format ref="ex:GeneralFormat" />
+    </appinfo>
+  </annotation>
+
+  <element name="test01" type="xs:string" dfdl:lengthKind="delimited" />
+
+  <element name="test02" type="xs:string" dfdl:lengthKind="delimited" />
+
+</schema>

--- a/src/sbt-test/sbt-daffodil/saved-parsers-05/test.script
+++ b/src/sbt-test/sbt-daffodil/saved-parsers-05/test.script
@@ -1,0 +1,23 @@
+## Licensed to the Apache Software Foundation (ASF) under one
+## or more contributor license agreements.  See the NOTICE file
+## distributed with this work for additional information
+## regarding copyright ownership.  The ASF licenses this file
+## to you under the Apache License, Version 2.0 (the
+## "License"); you may not use this file except in compliance
+## with the License.  You may obtain a copy of the License at
+## 
+##  http://www.apache.org/licenses/LICENSE-2.0
+## 
+## Unless required by applicable law or agreed to in writing,
+## software distributed under the License is distributed on an
+## "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+## KIND, either express or implied.  See the License for the
+## specific language governing permissions and limitations
+## under the License.
+## 
+
+> packageDaffodilBin
+$ exists target/test-0.1-daffodil350.bin
+$ exists target/test-0.1-daffodil360.bin
+$ exists target/test-0.1-two-daffodil350.bin
+$ exists target/test-0.1-two-daffodil360.bin


### PR DESCRIPTION
It is possible for a schema resource path in daffodilPackageBinInfos to resolve to a path inside jar, such as when the main schema is in a dependency jar or when the exportJars setting is true. If we try to convert the resolved resource to a File for the compileFile API, the jar URIs fail with a confusing exception.

To fix this, this switches to the compileSource API, which supports compiling schemas with either file:// or jar:// URIs.

Closes #3