### PR TITLE
Get JVM options from packageDaffodilBin/javaOptions instead of environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,15 @@ If used, one may want to use the first value of this setting to configure
 daffodilVersion := daffodilPackageBinVersions.value.head
 ```
 
+Some complex schemas require more memory or a larger stack size than Java
+provides by default. Change the `packageDaffodilBin / javaOptions` setting in
+build.sbt to increase these sizes, or more generally to specify options to
+provide to the JVM used to save parsers. For example:
+
+```scala
+packageDaffodilBin / javaOptions ++= Seq("-Xmx8G", "-Xss4m")
+```
+
 ### Saved Parsers in TDML Tests
 
 For schemas that take a long time to compile, it is often convenient to use a

--- a/src/main/scala/org/apache/daffodil/DaffodilPlugin.scala
+++ b/src/main/scala/org/apache/daffodil/DaffodilPlugin.scala
@@ -297,6 +297,9 @@ object DaffodilPlugin extends AutoPlugin {
     packageDaffodilBin := {
       val logger = streams.value.log
 
+      // options to provide to the forked JVM process used to save a processor
+      val jvmArgs = (packageDaffodilBin / javaOptions).value
+
       // this plugin jar includes a forkable main class that does the actual schema compilation
       // and saving.
       val pluginJar =
@@ -352,16 +355,7 @@ object DaffodilPlugin extends AutoPlugin {
             val targetName = s"${name.value}-${version.value}-${classifier}.bin"
             val targetFile = target.value / targetName
 
-            // extract options out of DAFFODIL_JAVA_OPTS or JAVA_OPTS environment variables.
-            // Note that this doesn't handle escaped spaces or quotes correctly, but that
-            // hopefully shouldn't be needed for specifying java options
-            val envArgs = None
-              .orElse(sys.env.get("DAFFODIL_JAVA_OPTS"))
-              .orElse(sys.env.get("JAVA_OPTS"))
-              .map(_.split("\\s+").toSeq)
-              .getOrElse(Seq.empty)
-
-            val args = envArgs ++ Seq(
+            val args = jvmArgs ++ Seq(
               "-classpath",
               classpathFiles.mkString(File.pathSeparator),
               mainClass,

--- a/src/sbt-test/sbt-daffodil/saved-parsers-06/build.sbt
+++ b/src/sbt-test/sbt-daffodil/saved-parsers-06/build.sbt
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+version := "0.1"
+
+name := "test"
+
+organization := "com.example"
+
+enablePlugins(DaffodilPlugin)
+
+packageDaffodilBin / javaOptions ++= Seq("-XshouldErrorIfUsed")
+
+daffodilPackageBinInfos := Seq(
+  DaffodilBinInfo("/test.dfdl.xsd"),
+)
+
+daffodilPackageBinVersions := Seq("3.6.0")
+
+daffodilVersion := daffodilPackageBinVersions.value.head

--- a/src/sbt-test/sbt-daffodil/saved-parsers-06/project/plugins.sbt
+++ b/src/sbt-test/sbt-daffodil/saved-parsers-06/project/plugins.sbt
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+addSbtPlugin("org.apache.daffodil" % "sbt-daffodil" % sys.props("plugin.version"))

--- a/src/sbt-test/sbt-daffodil/saved-parsers-06/src/main/resources/test.dfdl.xsd
+++ b/src/sbt-test/sbt-daffodil/saved-parsers-06/src/main/resources/test.dfdl.xsd
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<schema
+  xmlns="http://www.w3.org/2001/XMLSchema" 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:ex="http://example.com"
+  targetNamespace="http://example.com"
+  elementFormDefault="unqualified">
+
+  <include schemaLocation="/org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+
+  <annotation>
+    <appinfo source="http://www.ogf.org/dfdl/">
+      <dfdl:format ref="ex:GeneralFormat" />
+    </appinfo>
+  </annotation>
+
+  <element name="test01" type="xs:string" dfdl:lengthKind="delimited" />
+
+</schema>

--- a/src/sbt-test/sbt-daffodil/saved-parsers-06/test.script
+++ b/src/sbt-test/sbt-daffodil/saved-parsers-06/test.script
@@ -1,0 +1,26 @@
+## Licensed to the Apache Software Foundation (ASF) under one
+## or more contributor license agreements.  See the NOTICE file
+## distributed with this work for additional information
+## regarding copyright ownership.  The ASF licenses this file
+## to you under the Apache License, Version 2.0 (the
+## "License"); you may not use this file except in compliance
+## with the License.  You may obtain a copy of the License at
+## 
+##  http://www.apache.org/licenses/LICENSE-2.0
+## 
+## Unless required by applicable law or agreed to in writing,
+## software distributed under the License is distributed on an
+## "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+## KIND, either express or implied.  See the License for the
+## specific language governing permissions and limitations
+## under the License.
+## 
+
+# should fail because of the unrecognized option added to
+# packageDaffodilBin/javaOptions in build.sbt
+-> packageDaffodilBin
+
+# fix javaOptions and retry
+> set packageDaffodilBin / javaOptions := Seq("-Xmx128m")
+> packageDaffodilBin
+$ exists target/test-0.1-daffodil360.bin


### PR DESCRIPTION
Some schema are so large and complex that they need to specify additional JVM options to increase memory/stack size when forking the DaffodilSaver to compile and save processors using packageDaffodilBin task. The plugin already supports this by incorporating options from DAFFODIL_JAVA_OPTS or JAVA_OPTS, but that causes projects to rely on often undocumented memory requirements or environment settings. This can make it difficult to compile schemas if you don't know what settings are needed, or could lead to unexpected errors if invalid values are added to environment variables. This is fragile and probably not something we should support.

To fix this, this removes support for DAFFODIL_JAVA_OPTS and JAVA_OPTS, and instead gets additional JVM options from the `packageDaffodilBin/javaOptions` SBT setting. This way any additional JVM options must be specified and documented in build.sbt and should work anywhere without the need to configure the environment.

Closes #51