### PR TITLE
Updates for Daffodil 3.9.0

### DIFF
--- a/src/main/scala/org/apache/daffodil/DaffodilPlugin.scala
+++ b/src/main/scala/org/apache/daffodil/DaffodilPlugin.scala
@@ -163,7 +163,7 @@ object DaffodilPlugin extends AutoPlugin {
     /**
      * Default Daffodil version
      */
-    daffodilVersion := "3.8.0",
+    daffodilVersion := "3.9.0",
 
     /**
      * Disable uncommon features by default, schema projects must explicitly enable them to use

--- a/src/sbt-test/sbt-daffodil/versions-01/test.script
+++ b/src/sbt-test/sbt-daffodil/versions-01/test.script
@@ -16,6 +16,12 @@
 ## under the License.
 ## 
 
+> set daffodilVersion := "3.9.0"
+> packageDaffodilBin
+$ exists target/test-0.1-daffodil390.bin
+> test
+> clean
+
 > set daffodilVersion := "3.8.0"
 > packageDaffodilBin
 $ exists target/test-0.1-daffodil380.bin


### PR DESCRIPTION
- Default daffodilVersion setting to 3.9.0
- Add test to make sure daffodilVersion := 3.9.0 works

Closes #57