### PR TITLE
Use "provided" scope for layer/charset/udf dependencies

### DIFF
--- a/src/main/scala/org/apache/daffodil/DaffodilPlugin.scala
+++ b/src/main/scala/org/apache/daffodil/DaffodilPlugin.scala
@@ -202,7 +202,7 @@ object DaffodilPlugin extends AutoPlugin {
      */
     libraryDependencies ++= {
       if (daffodilBuildsCharset.value) {
-        Seq("org.apache.daffodil" %% "daffodil-io" % daffodilVersion.value)
+        Seq("org.apache.daffodil" %% "daffodil-io" % daffodilVersion.value % "provided")
       } else {
         Seq()
       }
@@ -213,7 +213,9 @@ object DaffodilPlugin extends AutoPlugin {
      */
     libraryDependencies ++= {
       if (daffodilBuildsLayer.value) {
-        Seq("org.apache.daffodil" %% "daffodil-runtime1-layers" % daffodilVersion.value)
+        Seq(
+          "org.apache.daffodil" %% "daffodil-runtime1-layers" % daffodilVersion.value % "provided",
+        )
       } else {
         Seq()
       }
@@ -224,7 +226,7 @@ object DaffodilPlugin extends AutoPlugin {
      */
     libraryDependencies ++= {
       if (daffodilBuildsUDF.value) {
-        Seq("org.apache.daffodil" %% "daffodil-udf" % daffodilVersion.value)
+        Seq("org.apache.daffodil" %% "daffodil-udf" % daffodilVersion.value % "provided")
       } else {
         Seq()
       }


### PR DESCRIPTION
If a project implements a Daffodil layer, character set, or user defined function plugin, and enables the associated setting, then we add the appropriate Daffodil library as a dependency. This is necessary to compile the plugin. However, this means that any schema projects that depend on the layer/charset/udf plugin will now transitively pull in Daffodil as a dependency.

In most cases, this doesn't really matter because the transitive dependencies will be overridden by `daffodilVersion`, or if you use `sbt "export fullClasspath"` to set DAFFODIL_CLASSPATH, the CLI will override any Daffodil dependencies.

But, even though this transitive dependency is never really used it still clutters up the dependency listings and can make it difficult to see what the real dependencies are. Since Daffodil jars will almost always be provided by what ever actually uses these plugins and schemas, this sets those dependencies to the "provided" scope. This allows the plugins to be compiled, but will not cause Daffodil jars to be transitively pulled it.

Note that as a rule of thumb, all dependencies to a daffodil jar probably want to either be in the "test" or "provided" scopes. All dependencies this plug adds now follow that rule.

Closes #63