### PR TITLE
Add support for publishArtifact setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,15 +159,19 @@ target/format-1.0-file-daffodil360.bin
 Note that the artifact names have the suffix "daffodilXYZ".bin, where XYZ is
 the version of Daffodil the saved parser is compatible with.
 
-The `publish`, `publishLocal`, `publishM2` and related publish tasks are
-modified to automatically build and publish the saved parsers as a new
-artifacts.
-
 If used, one may want to use the first value of this setting to configure
 `daffodilVersion`, e.g.:
 
 ```scala
 daffodilVersion := daffodilPackageBinVersions.value.head
+```
+
+The `publish`, `publishLocal`, `publishM2` and related publish tasks are
+modified to automatically build and publish the saved parsers as new artifacts.
+To disable publishing saved parsrs, add the following setting to build.sbt:
+
+```scala
+packageDaffodilBin / publishArtifact := false
 ```
 
 Some complex schemas require more memory or a larger stack size than Java

--- a/src/main/scala/org/apache/daffodil/DaffodilPlugin.scala
+++ b/src/main/scala/org/apache/daffodil/DaffodilPlugin.scala
@@ -426,20 +426,31 @@ object DaffodilPlugin extends AutoPlugin {
      * These two settings tell sbt about the artifacts and the task that generates the artifacts
      * so it knows to generate and publish them when publish/publihLocal/publishM2 is run
      */
-    artifacts ++= (packageDaffodilBin / artifacts).value,
-    packagedArtifacts := {
-      val arts = (packageDaffodilBin / artifacts).value
-      val files = (packageDaffodilBin / products).value
-
-      // the artifacts and associated files are not necessarily in the same order. For each
-      // artifact, we need to find the associated file (the one that ends with the same
-      // classifier and extension) and update the packagedArtifacts setting with that pair
-      val updatedPackagedArtifacts = arts.foldLeft(packagedArtifacts.value) { case (pa, art) =>
-        val suffix = s"-${art.classifier.get}.${art.extension}"
-        val file = files.find { _.getName.endsWith(suffix) }.get
-        pa.updated(art, file)
+    artifacts ++= {
+      if ((packageDaffodilBin / publishArtifact).value) {
+        (packageDaffodilBin / artifacts).value,
+      } else {
+        Seq()
       }
-      updatedPackagedArtifacts
+    },
+    packagedArtifacts := {
+      if ((packageDaffodilBin / publishArtifact).value) {
+        val arts = (packageDaffodilBin / artifacts).value
+        val files = (packageDaffodilBin / products).value
+
+        // the artifacts and associated files are not necessarily in the same order. For each
+        // artifact, we need to find the associated file (the one that ends with the same
+        // classifier and extension) and update the packagedArtifacts setting with that pair
+        val updatedPackagedArtifacts = arts.foldLeft(packagedArtifacts.value) {
+          case (pa, art) =>
+            val suffix = s"-${art.classifier.get}.${art.extension}"
+            val file = files.find { _.getName.endsWith(suffix) }.get
+            pa.updated(art, file)
+        }
+        updatedPackagedArtifacts
+      } else {
+        packagedArtifacts.value
+      }
     },
 
     /**

--- a/src/sbt-test/sbt-daffodil/saved-parsers-01/test.script
+++ b/src/sbt-test/sbt-daffodil/saved-parsers-01/test.script
@@ -16,16 +16,29 @@
 ## under the License.
 ## 
 
-> packageDaffodilBin
+> set publishTo := Some(Resolver.file("file", new File("target/ivy-publish/")))
+
+> publish
 $ exists target/test-0.1-daffodil350.bin
 $ exists target/test-0.1-daffodil360.bin
 $ exists target/test-0.1-two-daffodil350.bin
 $ exists target/test-0.1-two-daffodil360.bin
-
-> set publishTo := Some(Resolver.file("file", new File("target/ivy-publish/")))
-> publish
 $ exists target/ivy-publish/com/example/test/0.1/test-0.1.jar
 $ exists target/ivy-publish/com/example/test/0.1/test-0.1-daffodil350.bin
 $ exists target/ivy-publish/com/example/test/0.1/test-0.1-daffodil360.bin
 $ exists target/ivy-publish/com/example/test/0.1/test-0.1-two-daffodil350.bin
 $ exists target/ivy-publish/com/example/test/0.1/test-0.1-two-daffodil360.bin
+
+> clean
+
+> set packageDaffodilBin/publishArtifact := false
+> publish
+$ exists target/ivy-publish/com/example/test/0.1/test-0.1.jar
+$ absent target/test-0.1-daffodil350.bin
+$ absent target/test-0.1-daffodil360.bin
+$ absent target/test-0.1-two-daffodil350.bin
+$ absent target/test-0.1-two-daffodil360.bin
+$ absent target/ivy-publish/com/example/test/0.1/test-0.1-daffodil350.bin
+$ absent target/ivy-publish/com/example/test/0.1/test-0.1-daffodil360.bin
+$ absent target/ivy-publish/com/example/test/0.1/test-0.1-two-daffodil350.bin
+$ absent target/ivy-publish/com/example/test/0.1/test-0.1-two-daffodil360.bin


### PR DESCRIPTION
SBT already defines a `publishArtifact` setting, but it is only used for packageBin, packageDoc, and packageSrc artifacts. By default it is not affect custom package tasks like packageDaffodilBin. This makes the plugin aware of this setting for packageDaffodilBin.

Nowk if packageDaffodilBin/publishArtifact is set to false then we do not modify the `artifacts` or `packagedArtifacts` settings so SBT does not know about the saved parser artifacts and will not publish them.

Closes #68