### PR TITLE
Display Daffodil logs in packageDaffodilBin task

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,18 @@ provide to the JVM used to save parsers. For example:
 packageDaffodilBin / javaOptions ++= Seq("-Xmx8G", "-Xss4m")
 ```
 
+In some cases it may be useful to enable more verbose logging when building a
+saved parser. To configure the log level, add the following to build.sbt:
+
+```scala
+packageDaffodilBin / logLevel := Level.Info
+```
+
+The above setting defaults to `Level.Warn` but can be set to `Level.Info` or
+`Level.Debug` for more verbosity. Note that this does not affect Schema
+Definition Warning or Error diagnostics--it only affects the Daffodil logging
+mechanism, usually intended for Daffodil developers.
+
 ### Saved Parsers in TDML Tests
 
 For schemas that take a long time to compile, it is often convenient to use a


### PR DESCRIPTION
We currently add slf4j-nop to the packageDaffodilBin classpath which silently drops all log messages from Daffodil. Sometimes these log messages could be very helpful.

To enable this, this replaces slf4j-nop with slf4j-simple which just outputs to the console. This also defines a number of system properites so that packageDaffodilBin/logLevel is used to control the log level sl4fj and log4j loggers. This also make log messages go to stdout instead of the default stderr, since SBT makes strderr messages look like errors, when in reality these are just information messages about schema compilation.

Fixes #75