### PR TITLE
Update CI Java and MacOS versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,15 +39,17 @@ jobs:
       fail-fast: false
       matrix:
         java_distribution: [ temurin ]
-        java_version: [ 8, 11, 17 ]
+        java_version: [ 8, 11, 17, 21 ]
         scala_version: [ 2.12.18 ]
-        os: [ ubuntu-22.04, windows-2022, macos-12 ]
+        os: [ ubuntu-22.04, windows-2022, macos-14 ]
         exclude:
           # only run macos on java 17
-          - os: macos-12
+          - os: macos-14
             java_version: 8
-          - os: macos-12
+          - os: macos-14
             java_version: 11
+          - os: macos-14
+            java_version: 21
         include:
           - shell: bash
           - os: windows-2022
@@ -65,6 +67,10 @@ jobs:
       ############################################################
       # Setup
       ############################################################
+
+      - name: Install Dependencies (macOS)
+        if: runner.os == 'macOS'
+        run: brew install sbt
 
       - name: Check out Repository
         uses: actions/checkout@v4.1.1


### PR DESCRIPTION
- Add build matrix for Java 21
- Update MacOS to 14 since 12 is no longer supported by GitHub
- Install SBT for MacOS 14, GitHub does not include SBT by default in MacOS 14

Closes #81