### PR TITLE
Support exporting the packageDaffodilBin task

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,14 @@ provide to the JVM used to save parsers. For example:
 packageDaffodilBin / javaOptions ++= Seq("-Xmx8G", "-Xss4m")
 ```
 
+It can sometimes be useful to build a saved parser using the CLI or in an IDE.
+Run the following command to output a CLI command that is equivalent to the
+`packageDaffodilBin` task:
+
+```bash
+sbt "export packageDaffodilBin"
+```
+
 ### Saved Parsers in TDML Tests
 
 For schemas that take a long time to compile, it is often convenient to use a

--- a/src/main/scala/org/apache/daffodil/DaffodilPlugin.scala
+++ b/src/main/scala/org/apache/daffodil/DaffodilPlugin.scala
@@ -23,6 +23,7 @@ import scala.util.Properties
 
 import sbt.Keys._
 import sbt._
+import sbt.internal.CommandStrings.ExportStream
 
 object DaffodilPlugin extends AutoPlugin {
 
@@ -298,6 +299,7 @@ object DaffodilPlugin extends AutoPlugin {
     },
     packageDaffodilBin / products := {
       val logger = streams.value.log
+      val exporter = (packageDaffodilBin / streams).value.text(ExportStream)
 
       // options to provide to the forked JVM process used to save a processor
       val jvmArgs = (packageDaffodilBin / javaOptions).value
@@ -388,6 +390,16 @@ object DaffodilPlugin extends AutoPlugin {
               dbi.root.getOrElse(""),
               dbi.config.map { _.toString }.getOrElse("")
             )
+
+            // SBT has the concept of an "export stream"--this is a stream that an SBT task can
+            // write to to indicate its equivalent command line program and options. This is
+            // useful for debugging, allowing one to manually run an SBT task in a CLI. To
+            // support this for packageDaffodilBin, we just need to get the exporter stream
+            // above and write the equivalent command line to that stream. For a user to see
+            // this stream, they can run "sbt 'export packageDaffodilBin'". Note that this wraps
+            // the arguments in singles quotes to support arguments that might have spaces,
+            // be empty, or have special characters.
+            exporter.println("java " + args.map(arg => s"'$arg'").mkString(" "))
 
             logger.info(s"compiling daffodil parser to ${targetFile} ...")
 


### PR DESCRIPTION
It is currently difficult to debug the packageDaffodilBin task because it is forked by SBT as a separate process. To make it easier to debug, this writes the command that packageDaffodilBin fork/execs to the export stream. Users can then run 'sbt "export packageDaffodilBin"' to view that command, which can then be manullay run, copied into a shell script, added to an IDE for debugging, etc.

Closes #76
Closes #80