### PR TITLE
Add support for daffodil-tdml-junit library

### DIFF
--- a/src/main/scala/org/apache/daffodil/DaffodilPlugin.scala
+++ b/src/main/scala/org/apache/daffodil/DaffodilPlugin.scala
@@ -182,9 +182,29 @@ object DaffodilPlugin extends AutoPlugin {
       // version specifier Seq is empty, the associated dependencies are added regardless of
       // Daffodil version
       val versionedDeps = Map(
-        // always add Daffodil and junit test dependencies
-        ">=3.0.0" -> Seq(
+        // For daffodil 3.10.0 or newer, depend on daffodil-tdml-junit. This transitively pulls
+        // in daffodil-tdml-processor and gives access to the compact tdml runner API
+        ">=3.10.0" -> Seq(
+          "org.apache.daffodil" %% "daffodil-tdml-junit" % daffodilVersion.value % "test"
+        ),
+        // For older versions where daffodil-tdml-junit isn't available, depend on
+        // daffodil-tdml-processor plus an *intransitive* dependency to the 3.10.0 version of
+        // daffodil-tdml-junit. The daffodil-tdml-junit library uses an API that works with
+        // daffodil-tdml-processor 3.2.0 or newer. Note that this should be pinned to 3.10.0,
+        // since future versions of daffodil-tdml-junit might depend on a specific versions of
+        // daffodil-tdml-processor
+        ">=3.2.0 <3.10.0" -> Seq(
           "org.apache.daffodil" %% "daffodil-tdml-processor" % daffodilVersion.value % "test",
+          ("org.apache.daffodil" %% "daffodil-tdml-junit" % "3.10.0" % "test").intransitive()
+        ),
+        // The TDML Runner API that daffodil-tdml-junit-3.10.0 uses was added in Daffodil 3.2.0.
+        // So the new compact JUnit API cannot be used with 3.1.0 or older. For these projects,
+        // just add daffodil-tdml-processor so they can at least use the old TDML Runner API
+        ">=3.0.0 <3.2.0" -> Seq(
+          "org.apache.daffodil" %% "daffodil-tdml-processor" % daffodilVersion.value % "test"
+        ),
+        // junit dependencies
+        ">=3.0.0" -> Seq(
           "junit" % "junit" % "4.13.2" % "test",
           "com.github.sbt" % "junit-interface" % "0.13.2" % "test"
         ),

--- a/src/sbt-test/sbt-daffodil/tdml-junit-01/build.sbt
+++ b/src/sbt-test/sbt-daffodil/tdml-junit-01/build.sbt
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+version := "0.1"
+
+name := "test"
+
+organization := "com.example"
+
+enablePlugins(DaffodilPlugin)

--- a/src/sbt-test/sbt-daffodil/tdml-junit-01/project/plugins.sbt
+++ b/src/sbt-test/sbt-daffodil/tdml-junit-01/project/plugins.sbt
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+addSbtPlugin("org.apache.daffodil" % "sbt-daffodil" % sys.props("plugin.version"))

--- a/src/sbt-test/sbt-daffodil/tdml-junit-01/src/main/resources/com/example/test.dfdl.xsd
+++ b/src/sbt-test/sbt-daffodil/tdml-junit-01/src/main/resources/com/example/test.dfdl.xsd
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<schema
+  xmlns="http://www.w3.org/2001/XMLSchema" 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:ex="http://example.com"
+  targetNamespace="http://example.com"
+  elementFormDefault="unqualified">
+
+  <include schemaLocation="/org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+
+  <annotation>
+    <appinfo source="http://www.ogf.org/dfdl/">
+      <dfdl:format ref="ex:GeneralFormat" />
+    </appinfo>
+  </annotation>
+
+  <element name="test01" type="xs:string" dfdl:lengthKind="delimited" />
+
+</schema>

--- a/src/sbt-test/sbt-daffodil/tdml-junit-01/src/test/resources/com/example/test.tdml
+++ b/src/sbt-test/sbt-daffodil/tdml-junit-01/src/test/resources/com/example/test.tdml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<testSuite
+  xmlns="http://www.ibm.com/xmlns/dfdl/testData"
+  xmlns:tdml="http://www.ibm.com/xmlns/dfdl/testData"
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:ex="http://example.com">
+
+  <parserTestCase name="test01" root="test01" model="com/example/test.dfdl.xsd">
+    <document>
+      <documentPart type="text">testing</documentPart>
+    </document>
+    <infoset>
+      <dfdlInfoset>
+        <ex:test01>testing</ex:test01>
+      </dfdlInfoset>
+    </infoset>
+  </parserTestCase>
+
+</testSuite>

--- a/src/sbt-test/sbt-daffodil/tdml-junit-01/src/test/scala/com/example/test.scala
+++ b/src/sbt-test/sbt-daffodil/tdml-junit-01/src/test/scala/com/example/test.scala
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example
+
+import org.apache.daffodil.junit.tdml.TdmlSuite
+import org.apache.daffodil.junit.tdml.TdmlTests
+
+import org.junit.Test
+
+object TestExample extends TdmlSuite {
+  val tdmlResource = "/com/example/test.tdml"
+}
+
+class TestExample extends TdmlTests {
+  val tdmlSuite = TestExample
+
+  @Test def test01 = test
+}

--- a/src/sbt-test/sbt-daffodil/tdml-junit-01/test.script
+++ b/src/sbt-test/sbt-daffodil/tdml-junit-01/test.script
@@ -1,0 +1,34 @@
+## Licensed to the Apache Software Foundation (ASF) under one
+## or more contributor license agreements.  See the NOTICE file
+## distributed with this work for additional information
+## regarding copyright ownership.  The ASF licenses this file
+## to you under the Apache License, Version 2.0 (the
+## "License"); you may not use this file except in compliance
+## with the License.  You may obtain a copy of the License at
+## 
+##  http://www.apache.org/licenses/LICENSE-2.0
+## 
+## Unless required by applicable law or agreed to in writing,
+## software distributed under the License is distributed on an
+## "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+## KIND, either express or implied.  See the License for the
+## specific language governing permissions and limitations
+## under the License.
+## 
+
+> set daffodilVersion := "3.10.0"
+> test
+> clean
+
+> set daffodilVersion := "3.9.0"
+> test
+> clean
+
+> set daffodilVersion := "3.2.0"
+> test
+> clean
+
+# TDML JUnit API will fail with Daffodil 3.1.0 or older
+> set daffodilVersion := "3.1.0"
+-> test
+> clean


### PR DESCRIPTION
This adds a dependency to daffodil-tdml-junit so that DFDL schema projects can now make use of the much more compact TDML Runner API when using JUnit for testing.

Note that this adds the dependency for all Daffodil versions 3.2.0 or newer, so that even older DFDL schema projects can use the more compact syntax. This is done by making it an intranstive dependency for older versions.

Closes #84