### PR TITLE
Change default version of Daffodil to 3.11.0

### DIFF
--- a/src/main/scala/org/apache/daffodil/DaffodilPlugin.scala
+++ b/src/main/scala/org/apache/daffodil/DaffodilPlugin.scala
@@ -220,7 +220,7 @@ object DaffodilPlugin extends AutoPlugin {
     /**
      * Default Daffodil version
      */
-    daffodilVersion := "3.10.0",
+    daffodilVersion := "3.11.0",
 
     /**
      * Disable uncommon features by default, schema projects must explicitly enable them to use


### PR DESCRIPTION
I know that this we are in a weird state right now, but I think it make sense for version 1.4.0 of the Daffodil SBT plugin to default to targeting Daffodil 3.11.0.