### PR TITLE
Support namespaces and whitespace in Daffodil config files

### DIFF
--- a/src/main/java/org/apache/daffodil/DaffodilSaver.java
+++ b/src/main/java/org/apache/daffodil/DaffodilSaver.java
@@ -121,15 +121,20 @@ public class DaffodilSaver {
     // compiler = compiler.withTunable(...)
     if (config != null) {
       DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+      factory.setNamespaceAware(true);
       DocumentBuilder builder = factory.newDocumentBuilder();
       Document document = builder.parse(config);
-      NodeList tunables = document.getElementsByTagName("tunables");
+      NodeList tunables = document.getElementsByTagNameNS("urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:ext", "tunables");
       for (int i = 0; i < tunables.getLength(); i++) {
         Node tunablesNode = tunables.item(i);
         NodeList children = tunablesNode.getChildNodes();
         for (int j = 0; j < children.getLength(); j++) {
           Node node = children.item(j);
-          compiler = compilerWithTunable.invoke(compiler, node.getNodeName(), node.getTextContent());
+          if (node.getNodeType() != Node.ELEMENT_NODE) {
+            // ignore text nodes
+            continue;
+          }
+          compiler = compilerWithTunable.invoke(compiler, node.getLocalName(), node.getTextContent().trim());
         }
       }
     }


### PR DESCRIPTION
Commit dfe5e05259 rewrote DaffodilSaver in java, but the switch from Scala XML to Java DOM was not done correctly. The Java logic is not namespace aware and does not properly ignore whitespace, so config files using namespace prefixes or have extra whitespace can lead to ignored tunables or thrown exceptions.

To fix this, this changes the Java config parsing to be namespace-aware, specify the namespace when querying for the "tunables" element, ignore whitespace nodes, and trim tuanble values to strip leading/trailing whitespace.

Fixes #109