### PR TITLE
Add support for creating cross daffodil version projects

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,15 +39,11 @@ jobs:
       fail-fast: false
       matrix:
         java_distribution: [ temurin ]
-        java_version: [ 8, 11, 17, 21 ]
+        java_version: [ 17, 21 ]
         scala_version: [ 2.12.18 ]
         os: [ ubuntu-22.04, windows-2022, macos-14 ]
         exclude:
           # only run macos on java 17
-          - os: macos-14
-            java_version: 8
-          - os: macos-14
-            java_version: 11
           - os: macos-14
             java_version: 21
         include:

--- a/src/sbt-test/sbt-daffodil/builds-charset-01/build.sbt
+++ b/src/sbt-test/sbt-daffodil/builds-charset-01/build.sbt
@@ -15,14 +15,12 @@
  * limitations under the License.
  */
 
-version := "0.1"
-
-name := "test"
-
-organization := "com.example"
-
-enablePlugins(DaffodilPlugin)
-
-daffodilVersion := "3.6.0"
-
-daffodilBuildsCharset := true
+val test = (project in file("."))
+  .settings(
+    version := "0.1",
+    name := "test",
+    organization := "com.example",
+    daffodilVersion := "3.6.0",
+    daffodilBuildsCharset := true,
+  )
+  .daffodilProject()

--- a/src/sbt-test/sbt-daffodil/builds-charset-01/test.script
+++ b/src/sbt-test/sbt-daffodil/builds-charset-01/test.script
@@ -17,9 +17,9 @@
 ## 
 
 
-# builds jar, with _2.12 in the name beause charsets are scala version specific
+# builds jar, with daffodilXYZ classifier because charsets are daffodil version specific
 > package
-$ exists target/scala-2.12/test_2.12-0.1.jar
+$ exists target/test-0.1-daffodil360.jar
 
 # expect compilation to fail without this setting
 > set daffodilBuildsCharset := false

--- a/src/sbt-test/sbt-daffodil/builds-layer-01/build.sbt
+++ b/src/sbt-test/sbt-daffodil/builds-layer-01/build.sbt
@@ -15,14 +15,12 @@
  * limitations under the License.
  */
 
-version := "0.1"
-
-name := "test"
-
-organization := "com.example"
-
-enablePlugins(DaffodilPlugin)
-
-daffodilVersion := "3.6.0"
-
-daffodilBuildsLayer := true
+val test = (project in file("."))
+  .settings(
+    version := "0.1",
+    name := "test",
+    organization := "com.example",
+    daffodilVersion := "3.6.0",
+    daffodilBuildsLayer := true,
+  )
+  .daffodilProject()

--- a/src/sbt-test/sbt-daffodil/builds-layer-01/test.script
+++ b/src/sbt-test/sbt-daffodil/builds-layer-01/test.script
@@ -17,9 +17,9 @@
 ## 
 
 
-# builds jar, with _2.12 in the name beause layers are scala version specific
+# builds jar, with daffodilXYZ classifier because layers are daffodil version specific
 > package
-$ exists target/scala-2.12/test_2.12-0.1.jar
+$ exists target/test-0.1-daffodil360.jar
 
 # expect compilation to fail without this setting
 > set daffodilBuildsLayer := false

--- a/src/sbt-test/sbt-daffodil/builds-udf-01/build.sbt
+++ b/src/sbt-test/sbt-daffodil/builds-udf-01/build.sbt
@@ -15,14 +15,12 @@
  * limitations under the License.
  */
 
-version := "0.1"
-
-name := "test"
-
-organization := "com.example"
-
-enablePlugins(DaffodilPlugin)
-
-daffodilVersion := "3.6.0"
-
-daffodilBuildsUDF := true
+val test = (project in file("."))
+  .settings(
+    version := "0.1",
+    name := "test",
+    organization := "com.example",
+    daffodilVersion := "3.6.0",
+    daffodilBuildsUDF := true,
+  )
+  .daffodilProject()

--- a/src/sbt-test/sbt-daffodil/builds-udf-01/test.script
+++ b/src/sbt-test/sbt-daffodil/builds-udf-01/test.script
@@ -17,9 +17,9 @@
 ## 
 
 
-# builds jar, with _2.12 in the name beause UDFs are scala version specific
+# builds jar, with daffodilXYZ classifier because udfs are daffodil version specific
 > package
-$ exists target/scala-2.12/test_2.12-0.1.jar
+$ exists target/test-0.1-daffodil360.jar
 
 # expect compilation to fail without this setting
 > set daffodilBuildsUDF := false

--- a/src/sbt-test/sbt-daffodil/common-settings-01/build.sbt
+++ b/src/sbt-test/sbt-daffodil/common-settings-01/build.sbt
@@ -15,12 +15,11 @@
  * limitations under the License.
  */
 
-version := "0.1"
-
-name := "test"
-
-organization := "com.example"
-
-enablePlugins(DaffodilPlugin)
-
-daffodilVersion := "3.6.0"
+val test = (project in file("."))
+  .settings(
+    version := "0.1",
+    name := "test",
+    organization := "com.example",
+    daffodilVersion := "3.6.0",
+  )
+  .daffodilProject()

--- a/src/sbt-test/sbt-daffodil/cross-versions-01/build.sbt
+++ b/src/sbt-test/sbt-daffodil/cross-versions-01/build.sbt
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+val test = (project in file("."))
+  .settings(
+    name := "test-plugin",
+    version := "0.1",
+    organization := "com.example",
+    daffodilVersion := "3.10.0",
+    daffodilBuildsLayer := true,
+  )
+  .daffodilProject(crossDaffodilVersions = Seq("3.11.0", "4.0.0"))

--- a/src/sbt-test/sbt-daffodil/cross-versions-01/project/plugins.sbt
+++ b/src/sbt-test/sbt-daffodil/cross-versions-01/project/plugins.sbt
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+addSbtPlugin("org.apache.daffodil" % "sbt-daffodil" % sys.props("plugin.version"))

--- a/src/sbt-test/sbt-daffodil/cross-versions-01/src/main/scala-daffodil-3.10.0/OnlyScala212.scala
+++ b/src/sbt-test/sbt-daffodil/cross-versions-01/src/main/scala-daffodil-3.10.0/OnlyScala212.scala
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Not an actual layer. This is only used to show plugins can include Daffodil version specific
+// files. This code should only compile on Scala 2.12 (used by Daffodil 3.10.0)
+
+object OnlyScala212 {
+  val l: TraversableOnce[Int] = List(1,2,3)
+}

--- a/src/sbt-test/sbt-daffodil/cross-versions-01/src/main/scala-daffodil-3.11.0/OnlyScala213.scala
+++ b/src/sbt-test/sbt-daffodil/cross-versions-01/src/main/scala-daffodil-3.11.0/OnlyScala213.scala
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Not an actual layer. This is only used to show plugins can include Daffodil version specific
+// files. This code should only compile on Scala 2.13 (used by Daffodil 3.11.0)
+
+object OnlyScala213 {
+  val l: LazyList[Int] = LazyList(1, 2, 3) // fails in Scala 2.12
+  val s = 'mySymbol // fails in Scala 3
+}

--- a/src/sbt-test/sbt-daffodil/cross-versions-01/src/main/scala-daffodil-4.0.0/OnlyScala3.scala
+++ b/src/sbt-test/sbt-daffodil/cross-versions-01/src/main/scala-daffodil-4.0.0/OnlyScala3.scala
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Not an actual layer. This is only used to show plugins can include Daffodil version specific
+// files. This code should only compile on Scala 3 (used by Daffodil 4.0.0)
+
+// enum is a new keyword in Scala 3
+enum OnlyScala3 {
+  case A, B, C
+}
+

--- a/src/sbt-test/sbt-daffodil/cross-versions-01/src/main/scala/AllScala.scala
+++ b/src/sbt-test/sbt-daffodil/cross-versions-01/src/main/scala/AllScala.scala
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Not an actual layer. This is only used to show plugins can share scala files.
+// This will be included for all cross versions and is compatiable accross all versions of
+// Daffodil/Scala.
+
+class AllScala {
+  val xs = Seq(1,2,3)
+}

--- a/src/sbt-test/sbt-daffodil/cross-versions-01/test.script
+++ b/src/sbt-test/sbt-daffodil/cross-versions-01/test.script
@@ -1,0 +1,56 @@
+## Licensed to the Apache Software Foundation (ASF) under one
+## or more contributor license agreements.  See the NOTICE file
+## distributed with this work for additional information
+## regarding copyright ownership.  The ASF licenses this file
+## to you under the Apache License, Version 2.0 (the
+## "License"); you may not use this file except in compliance
+## with the License.  You may obtain a copy of the License at
+## 
+##  http://www.apache.org/licenses/LICENSE-2.0
+## 
+## Unless required by applicable law or agreed to in writing,
+## software distributed under the License is distributed on an
+## "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+## KIND, either express or implied.  See the License for the
+## specific language governing permissions and limitations
+## under the License.
+## 
+
+> package
+$ exists target/test-plugin-0.1-daffodil3100.jar
+$ exists target/classes/OnlyScala212.class
+$ exists target/classes/AllScala.class
+
+$ absent target/daffodil3110/test-plugin-0.1-daffodil3110.jar
+$ absent target/daffodil3110/classes/OnlyScala213.class
+$ absent target/daffodil3110/classes/AllScala.class
+
+$ absent target/daffodil400/test-plugin-0.1-daffodil400.jar
+$ absent target/daffodil400/classes/OnlyScala3.class
+$ absent target/daffodil400/classes/AllScala.class
+
+> test_daffodil3110/package
+$ exists target/daffodil3110/test-plugin-0.1-daffodil3110.jar
+$ exists target/daffodil3110/classes/OnlyScala213.class
+$ exists target/daffodil3110/classes/AllScala.class
+
+> test_daffodil400/package
+$ exists target/daffodil400/test-plugin-0.1-daffodil400.jar
+$ exists target/daffodil400/classes/OnlyScala3.class
+$ exists target/daffodil400/classes/AllScala.class
+
+> clean
+> set aggregate := true
+> package
+
+$ exists target/test-plugin-0.1-daffodil3100.jar
+$ exists target/classes/OnlyScala212.class
+$ exists target/classes/AllScala.class
+
+$ exists target/daffodil3110/test-plugin-0.1-daffodil3110.jar
+$ exists target/daffodil3110/classes/OnlyScala213.class
+$ exists target/daffodil3110/classes/AllScala.class
+
+$ exists target/daffodil400/test-plugin-0.1-daffodil400.jar
+$ exists target/daffodil400/classes/OnlyScala3.class
+$ exists target/daffodil400/classes/AllScala.class

--- a/src/sbt-test/sbt-daffodil/cross-versions-02/build.sbt
+++ b/src/sbt-test/sbt-daffodil/cross-versions-02/build.sbt
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+val test = (project in file("."))
+  .settings(
+    version := "0.1",
+    name := "test",
+    organization := "com.example",
+    daffodilPackageBinInfos := Seq(
+      DaffodilBinInfo("/com/example/test.dfdl.xsd")
+    ),
+    daffodilTdmlUsesPackageBin := true,
+    daffodilVersion := "3.10.0",
+  )
+  .daffodilProject(crossDaffodilVersions = Seq("3.11.0", "4.0.0"))

--- a/src/sbt-test/sbt-daffodil/cross-versions-02/project/plugins.sbt
+++ b/src/sbt-test/sbt-daffodil/cross-versions-02/project/plugins.sbt
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+addSbtPlugin("org.apache.daffodil" % "sbt-daffodil" % sys.props("plugin.version"))

--- a/src/sbt-test/sbt-daffodil/cross-versions-02/src/main/resources/com/example/test.dfdl.xsd
+++ b/src/sbt-test/sbt-daffodil/cross-versions-02/src/main/resources/com/example/test.dfdl.xsd
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<schema
+  xmlns="http://www.w3.org/2001/XMLSchema" 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:ex="http://example.com"
+  targetNamespace="http://example.com"
+  elementFormDefault="unqualified">
+
+  <include schemaLocation="/org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+
+  <annotation>
+    <appinfo source="http://www.ogf.org/dfdl/">
+      <dfdl:format ref="ex:GeneralFormat" />
+    </appinfo>
+  </annotation>
+
+  <element name="test01" type="xs:string" dfdl:lengthKind="delimited" />
+
+</schema>

--- a/src/sbt-test/sbt-daffodil/cross-versions-02/src/test/resources/com/example/test.tdml
+++ b/src/sbt-test/sbt-daffodil/cross-versions-02/src/test/resources/com/example/test.tdml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<testSuite
+  xmlns="http://www.ibm.com/xmlns/dfdl/testData"
+  xmlns:tdml="http://www.ibm.com/xmlns/dfdl/testData"
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:ex="http://example.com">
+
+  <parserTestCase name="test01" root="test01" model="/test.bin">
+    <document>
+      <documentPart type="text">testing</documentPart>
+    </document>
+    <infoset>
+      <dfdlInfoset>
+        <ex:test01>testing</ex:test01>
+      </dfdlInfoset>
+    </infoset>
+  </parserTestCase>
+
+</testSuite>

--- a/src/sbt-test/sbt-daffodil/cross-versions-02/src/test/scala/com/example/test.scala
+++ b/src/sbt-test/sbt-daffodil/cross-versions-02/src/test/scala/com/example/test.scala
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example
+
+import org.apache.daffodil.tdml.Runner
+
+import org.junit.AfterClass
+import org.junit.Test
+
+object TestExample {
+  lazy val runner = Runner("/com/example/", "test.tdml")
+
+  @AfterClass def shutdown: Unit = { runner.reset() }
+}
+
+class TestExample {
+  import TestExample._
+
+  @Test def test_test01(): Unit = { runner.runOneTest("test01") }
+}

--- a/src/sbt-test/sbt-daffodil/cross-versions-02/test.script
+++ b/src/sbt-test/sbt-daffodil/cross-versions-02/test.script
@@ -1,0 +1,51 @@
+## Licensed to the Apache Software Foundation (ASF) under one
+## or more contributor license agreements.  See the NOTICE file
+## distributed with this work for additional information
+## regarding copyright ownership.  The ASF licenses this file
+## to you under the Apache License, Version 2.0 (the
+## "License"); you may not use this file except in compliance
+## with the License.  You may obtain a copy of the License at
+## 
+##  http://www.apache.org/licenses/LICENSE-2.0
+## 
+## Unless required by applicable law or agreed to in writing,
+## software distributed under the License is distributed on an
+## "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+## KIND, either express or implied.  See the License for the
+## specific language governing permissions and limitations
+## under the License.
+## 
+
+> packageDaffodilBin
+$ exists target/test-0.1-daffodil3100.bin
+
+$ absent target/daffodil3110/test-0.1-daffodil3110.bin
+$ absent target/daffodil400/test-0.1-daffodil400.bin
+
+> test_daffodil3110/packageDaffodilBin
+$ exists target/daffodil3110/test-0.1-daffodil3110.bin
+
+> test_daffodil400/packageDaffodilBin
+$ exists target/daffodil400/test-0.1-daffodil400.bin
+
+> clean
+> set aggregate := true
+> packageDaffodilBin
+
+$ exists target/test-0.1-daffodil3100.bin
+$ exists target/daffodil3110/test-0.1-daffodil3110.bin
+$ exists target/daffodil400/test-0.1-daffodil400.bin
+
+> clean
+> set aggregate := false
+
+> set publishTo := Some(Resolver.file("file", new File("target/ivy-publish/")))
+> publish
+$ exists target/ivy-publish/com/example/test/0.1/test-0.1.jar
+$ exists target/ivy-publish/com/example/test/0.1/test-0.1-daffodil3100.bin
+$ exists target/ivy-publish/com/example/test/0.1/test-0.1-daffodil3100.bin
+$ exists target/ivy-publish/com/example/test/0.1/test-0.1-daffodil400.bin
+
+> test
+> test_daffodil3110/test
+> test_daffodil400/test

--- a/src/sbt-test/sbt-daffodil/cross-versions-03/build.sbt
+++ b/src/sbt-test/sbt-daffodil/cross-versions-03/build.sbt
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+val root = (project in file("."))
+
+val plugin = (project in file("plugin"))
+  .settings(
+    name := "test-plugin",
+    version := "0.1",
+    organization := "com.example",
+    daffodilVersion := "3.10.0",
+    daffodilBuildsCharset := true,
+  )
+  .daffodilProject(crossDaffodilVersions = Seq("3.11.0"))
+
+val schema = (project in file("schema"))
+  .settings(
+    name := "test-schema",
+    version := "0.1",
+    organization := "com.example",
+    daffodilVersion := "3.10.0",
+    daffodilPluginDependencies := Seq(
+      "com.example" % "test-plugin" % "0.1"
+    ),
+  )
+  .daffodilProject(crossDaffodilVersions = Seq("3.11.0", "4.0.0"))

--- a/src/sbt-test/sbt-daffodil/cross-versions-03/plugin/src/main/scala/Test.scala
+++ b/src/sbt-test/sbt-daffodil/cross-versions-03/plugin/src/main/scala/Test.scala
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Not an actual layer. This is only used to show plugins can be published and resolved
+
+class Test {
+  val xs = Seq(1,2,3)
+}

--- a/src/sbt-test/sbt-daffodil/cross-versions-03/project/plugins.sbt
+++ b/src/sbt-test/sbt-daffodil/cross-versions-03/project/plugins.sbt
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+addSbtPlugin("org.apache.daffodil" % "sbt-daffodil" % sys.props("plugin.version"))

--- a/src/sbt-test/sbt-daffodil/cross-versions-03/schema/src/main/resources/com/example/test.dfdl.xsd
+++ b/src/sbt-test/sbt-daffodil/cross-versions-03/schema/src/main/resources/com/example/test.dfdl.xsd
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<schema
+  xmlns="http://www.w3.org/2001/XMLSchema" 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:ex="http://example.com"
+  targetNamespace="http://example.com"
+  elementFormDefault="unqualified">
+
+  <include schemaLocation="/org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+
+  <annotation>
+    <appinfo source="http://www.ogf.org/dfdl/">
+      <dfdl:format ref="ex:GeneralFormat" />
+    </appinfo>
+  </annotation>
+
+  <element name="test01" type="xs:string" dfdl:lengthKind="delimited" />
+
+</schema>

--- a/src/sbt-test/sbt-daffodil/cross-versions-03/schema/src/test/resources/com/example/test.tdml
+++ b/src/sbt-test/sbt-daffodil/cross-versions-03/schema/src/test/resources/com/example/test.tdml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<testSuite
+  xmlns="http://www.ibm.com/xmlns/dfdl/testData"
+  xmlns:tdml="http://www.ibm.com/xmlns/dfdl/testData"
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:ex="http://example.com">
+
+  <parserTestCase name="test01" root="test01" model="/com/example/test.dfdl.xsd">
+    <document>
+      <documentPart type="text">testing</documentPart>
+    </document>
+    <infoset>
+      <dfdlInfoset>
+        <ex:test01>testing</ex:test01>
+      </dfdlInfoset>
+    </infoset>
+  </parserTestCase>
+
+</testSuite>

--- a/src/sbt-test/sbt-daffodil/cross-versions-03/schema/src/test/scala/com/example/test.scala
+++ b/src/sbt-test/sbt-daffodil/cross-versions-03/schema/src/test/scala/com/example/test.scala
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example
+
+import org.apache.daffodil.tdml.Runner
+
+import org.junit.AfterClass
+import org.junit.Test
+
+object TestExample {
+  lazy val runner = Runner("/com/example/", "test.tdml")
+
+  @AfterClass def shutdown: Unit = { runner.reset() }
+}
+
+class TestExample {
+  import TestExample._
+
+  @Test def test_test01(): Unit = { runner.runOneTest("test01") }
+}

--- a/src/sbt-test/sbt-daffodil/cross-versions-03/test.script
+++ b/src/sbt-test/sbt-daffodil/cross-versions-03/test.script
@@ -1,0 +1,33 @@
+## Licensed to the Apache Software Foundation (ASF) under one
+## or more contributor license agreements.  See the NOTICE file
+## distributed with this work for additional information
+## regarding copyright ownership.  The ASF licenses this file
+## to you under the Apache License, Version 2.0 (the
+## "License"); you may not use this file except in compliance
+## with the License.  You may obtain a copy of the License at
+## 
+##  http://www.apache.org/licenses/LICENSE-2.0
+## 
+## Unless required by applicable law or agreed to in writing,
+## software distributed under the License is distributed on an
+## "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+## KIND, either express or implied.  See the License for the
+## specific language governing permissions and limitations
+## under the License.
+## 
+
+# define a local file for publishing and resolving artifacts
+> set every publishTo := Some(Resolver.file("file", new File("target/ivy-publish/")))
+> set every resolvers := Seq("file" at new File("target/ivy-publish/").getAbsoluteFile.toURI.toString)
+
+# publish all versions of the plugin
+> plugin/publish
+
+# test only 3.10.0 with the plugin
+> schema/test
+
+# test only 3.11.0 with the plugin
+> schema_daffodil3110/test
+
+# test only 4.0.0 with the plugin, this fails because the plugin was not build for 4.0.0
+-> schema_daffodil400/test

--- a/src/sbt-test/sbt-daffodil/flat-layout-01/build.sbt
+++ b/src/sbt-test/sbt-daffodil/flat-layout-01/build.sbt
@@ -15,14 +15,12 @@
  * limitations under the License.
  */
 
-version := "0.1"
-
-name := "test"
-
-organization := "com.example"
-
-enablePlugins(DaffodilPlugin)
-
-daffodilVersion := "3.6.0"
-
-daffodilFlatLayout := true
+val test = (project in file("."))
+  .settings(
+    version := "0.1",
+    name := "test",
+    organization := "com.example",
+    daffodilVersion := "3.6.0",
+    daffodilFlatLayout := true,
+  )
+  .daffodilProject()

--- a/src/sbt-test/sbt-daffodil/saved-parsers-01/build.sbt
+++ b/src/sbt-test/sbt-daffodil/saved-parsers-01/build.sbt
@@ -15,19 +15,15 @@
  * limitations under the License.
  */
 
-version := "0.1"
-
-name := "test"
-
-organization := "com.example"
-
-enablePlugins(DaffodilPlugin)
-
-daffodilPackageBinInfos := Seq(
-  DaffodilBinInfo("/test.dfdl.xsd"),
-  DaffodilBinInfo("/test.dfdl.xsd", Some("test02"), Some("two"))
-)
-
-daffodilPackageBinVersions := Seq("3.6.0", "3.5.0")
-
-daffodilVersion := daffodilPackageBinVersions.value.head
+val test = (project in file("."))
+  .settings(
+    version := "0.1",
+    name := "test",
+    organization := "com.example",
+    daffodilPackageBinInfos := Seq(
+      DaffodilBinInfo("/test.dfdl.xsd"),
+      DaffodilBinInfo("/test.dfdl.xsd", Some("test02"), Some("two"))
+    ),
+    daffodilVersion := "3.6.0",
+  )
+  .daffodilProject(crossDaffodilVersions = Seq("3.5.0"))

--- a/src/sbt-test/sbt-daffodil/saved-parsers-01/test.script
+++ b/src/sbt-test/sbt-daffodil/saved-parsers-01/test.script
@@ -19,10 +19,10 @@
 > set publishTo := Some(Resolver.file("file", new File("target/ivy-publish/")))
 
 > publish
-$ exists target/test-0.1-daffodil350.bin
 $ exists target/test-0.1-daffodil360.bin
-$ exists target/test-0.1-two-daffodil350.bin
 $ exists target/test-0.1-two-daffodil360.bin
+$ exists target/daffodil350/test-0.1-daffodil350.bin
+$ exists target/daffodil350/test-0.1-two-daffodil350.bin
 $ exists target/ivy-publish/com/example/test/0.1/test-0.1.jar
 $ exists target/ivy-publish/com/example/test/0.1/test-0.1-daffodil350.bin
 $ exists target/ivy-publish/com/example/test/0.1/test-0.1-daffodil360.bin
@@ -32,12 +32,13 @@ $ exists target/ivy-publish/com/example/test/0.1/test-0.1-two-daffodil360.bin
 > clean
 
 > set packageDaffodilBin/publishArtifact := false
+> set test.daffodil("3.5.0")/packageDaffodilBin/publishArtifact := false
 > publish
 $ exists target/ivy-publish/com/example/test/0.1/test-0.1.jar
-$ absent target/test-0.1-daffodil350.bin
 $ absent target/test-0.1-daffodil360.bin
-$ absent target/test-0.1-two-daffodil350.bin
 $ absent target/test-0.1-two-daffodil360.bin
+$ absent target/daffodil350/test-0.1-daffodil350.bin
+$ absent target/daffodil350/test-0.1-two-daffodil350.bin
 $ absent target/ivy-publish/com/example/test/0.1/test-0.1-daffodil350.bin
 $ absent target/ivy-publish/com/example/test/0.1/test-0.1-daffodil360.bin
 $ absent target/ivy-publish/com/example/test/0.1/test-0.1-two-daffodil350.bin

--- a/src/sbt-test/sbt-daffodil/saved-parsers-02/build.sbt
+++ b/src/sbt-test/sbt-daffodil/saved-parsers-02/build.sbt
@@ -15,20 +15,16 @@
  * limitations under the License.
  */
 
-version := "0.1"
-
-name := "test"
-
-organization := "com.example"
-
-enablePlugins(DaffodilPlugin)
-
-// same as saved-parsers-01 but uses the old tuple syntax
-daffodilPackageBinInfos := Seq(
-  ("/test.dfdl.xsd", None, None),
-  ("/test.dfdl.xsd", Some("test02"), Some("two"))
-)
-
-daffodilPackageBinVersions := Seq("3.6.0", "3.5.0")
-
-daffodilVersion := daffodilPackageBinVersions.value.head
+val test = (project in file("."))
+  .settings(
+    version := "0.1",
+    name := "test",
+    organization := "com.example",
+    // same as saved-parsers-01 but uses the old tuple syntax
+    daffodilPackageBinInfos := Seq(
+      ("/test.dfdl.xsd", None, None),
+      ("/test.dfdl.xsd", Some("test02"), Some("two"))
+    ),
+    daffodilVersion := "3.6.0",
+  )
+  .daffodilProject(crossDaffodilVersions = Seq("3.5.0"))

--- a/src/sbt-test/sbt-daffodil/saved-parsers-02/test.script
+++ b/src/sbt-test/sbt-daffodil/saved-parsers-02/test.script
@@ -17,10 +17,12 @@
 ## 
 
 > packageDaffodilBin
-$ exists target/test-0.1-daffodil350.bin
 $ exists target/test-0.1-daffodil360.bin
-$ exists target/test-0.1-two-daffodil350.bin
 $ exists target/test-0.1-two-daffodil360.bin
+
+> test_daffodil350/packageDaffodilBin
+$ exists target/daffodil350/test-0.1-daffodil350.bin
+$ exists target/daffodil350/test-0.1-two-daffodil350.bin
 
 > set publishTo := Some(Resolver.file("file", new File("target/ivy-publish/")))
 > publish

--- a/src/sbt-test/sbt-daffodil/saved-parsers-03/build.sbt
+++ b/src/sbt-test/sbt-daffodil/saved-parsers-03/build.sbt
@@ -15,22 +15,18 @@
  * limitations under the License.
  */
 
-version := "0.1"
-
-name := "test"
-
-organization := "com.example"
-
-enablePlugins(DaffodilPlugin)
-
-daffodilPackageBinInfos := {
-  val config = Some((Compile / resourceDirectory).value / "test.cfg")
-  Seq(
-    DaffodilBinInfo("/test.dfdl.xsd", config = config),
-    DaffodilBinInfo("/test.dfdl.xsd", Some("test02"), Some("two"), config = config)
+val test = (project in file("."))
+  .settings(
+    version := "0.1",
+    name := "test",
+    organization := "com.example",
+    daffodilPackageBinInfos := {
+      val config = Some((Compile / resourceDirectory).value / "test.cfg")
+      Seq(
+        DaffodilBinInfo("/test.dfdl.xsd", config = config),
+        DaffodilBinInfo("/test.dfdl.xsd", Some("test02"), Some("two"), config = config)
+      )
+    },
+    daffodilVersion := "3.11.0",
   )
-}
-
-daffodilPackageBinVersions := Seq("3.11.0", "3.5.0")
-
-daffodilVersion := daffodilPackageBinVersions.value.head
+  .daffodilProject(crossDaffodilVersions = Seq("3.5.0"))

--- a/src/sbt-test/sbt-daffodil/saved-parsers-03/test.script
+++ b/src/sbt-test/sbt-daffodil/saved-parsers-03/test.script
@@ -17,7 +17,9 @@
 ## 
 
 > packageDaffodilBin
-$ exists target/test-0.1-daffodil350.bin
 $ exists target/test-0.1-daffodil3110.bin
-$ exists target/test-0.1-two-daffodil350.bin
 $ exists target/test-0.1-two-daffodil3110.bin
+
+> test_daffodil350/packageDaffodilBin
+$ exists target/daffodil350/test-0.1-daffodil350.bin
+$ exists target/daffodil350/test-0.1-two-daffodil350.bin

--- a/src/sbt-test/sbt-daffodil/saved-parsers-04/build.sbt
+++ b/src/sbt-test/sbt-daffodil/saved-parsers-04/build.sbt
@@ -15,16 +15,13 @@
  * limitations under the License.
  */
 
-version := "0.1"
-
-name := "test"
-
-organization := "com.example"
-
-enablePlugins(DaffodilPlugin)
-
-daffodilPackageBinInfos := Seq(
-  DaffodilBinInfo("/does-not-exist.dfdl.xsd")
-)
-
-daffodilPackageBinVersions := Seq(daffodilVersion.value)
+val test = (project in file("."))
+  .settings(
+    version := "0.1",
+    name := "test",
+    organization := "com.example",
+    daffodilPackageBinInfos := Seq(
+      DaffodilBinInfo("/does-not-exist.dfdl.xsd")
+    ),
+  )
+  .daffodilProject()

--- a/src/sbt-test/sbt-daffodil/saved-parsers-05/build.sbt
+++ b/src/sbt-test/sbt-daffodil/saved-parsers-05/build.sbt
@@ -15,24 +15,19 @@
  * limitations under the License.
  */
 
-version := "0.1"
-
-name := "test"
-
-organization := "com.example"
-
-// tells SBT to build a jar and put it on the classpath instead of putting src/main/resources on
-// the classpath. This means schema resource paths will resolve to a path inside a jar instead
-// of to a file
-exportJars := true
-
-enablePlugins(DaffodilPlugin)
-
-daffodilPackageBinInfos := Seq(
-  DaffodilBinInfo("/test.dfdl.xsd"),
-  DaffodilBinInfo("/test.dfdl.xsd", Some("test02"), Some("two"))
-)
-
-daffodilPackageBinVersions := Seq("3.6.0", "3.5.0")
-
-daffodilVersion := daffodilPackageBinVersions.value.head
+val test = (project in file("."))
+  .settings(
+    version := "0.1",
+    name := "test",
+    organization := "com.example",
+    // tells SBT to build a jar and put it on the classpath instead of putting src/main/resources on
+    // the classpath. This means schema resource paths will resolve to a path inside a jar instead
+    // of to a file
+    exportJars := true,
+    daffodilPackageBinInfos := Seq(
+      DaffodilBinInfo("/test.dfdl.xsd"),
+      DaffodilBinInfo("/test.dfdl.xsd", Some("test02"), Some("two"))
+    ),
+    daffodilVersion := "3.6.0",
+  )
+  .daffodilProject(crossDaffodilVersions = Seq("3.5.0"))

--- a/src/sbt-test/sbt-daffodil/saved-parsers-05/test.script
+++ b/src/sbt-test/sbt-daffodil/saved-parsers-05/test.script
@@ -17,7 +17,9 @@
 ## 
 
 > packageDaffodilBin
-$ exists target/test-0.1-daffodil350.bin
 $ exists target/test-0.1-daffodil360.bin
-$ exists target/test-0.1-two-daffodil350.bin
 $ exists target/test-0.1-two-daffodil360.bin
+
+> test_daffodil350/packageDaffodilBin
+$ exists target/daffodil350/test-0.1-daffodil350.bin
+$ exists target/daffodil350/test-0.1-two-daffodil350.bin

--- a/src/sbt-test/sbt-daffodil/saved-parsers-06/build.sbt
+++ b/src/sbt-test/sbt-daffodil/saved-parsers-06/build.sbt
@@ -15,20 +15,15 @@
  * limitations under the License.
  */
 
-version := "0.1"
-
-name := "test"
-
-organization := "com.example"
-
-enablePlugins(DaffodilPlugin)
-
-packageDaffodilBin / javaOptions ++= Seq("-XshouldErrorIfUsed")
-
-daffodilPackageBinInfos := Seq(
-  DaffodilBinInfo("/test.dfdl.xsd")
-)
-
-daffodilPackageBinVersions := Seq("3.6.0")
-
-daffodilVersion := daffodilPackageBinVersions.value.head
+val test = (project in file("."))
+  .settings(
+    version := "0.1",
+    name := "test",
+    organization := "com.example",
+    packageDaffodilBin / javaOptions ++= Seq("-XshouldErrorIfUsed"),
+    daffodilPackageBinInfos := Seq(
+      DaffodilBinInfo("/test.dfdl.xsd")
+    ),
+    daffodilVersion := "3.6.0",
+  )
+  .daffodilProject()

--- a/src/sbt-test/sbt-daffodil/tdml-junit-01/build.sbt
+++ b/src/sbt-test/sbt-daffodil/tdml-junit-01/build.sbt
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-version := "0.1"
-
-name := "test"
-
-organization := "com.example"
-
-enablePlugins(DaffodilPlugin)
+val test = (project in file("."))
+  .settings(
+    version := "0.1",
+    name := "test",
+    organization := "com.example",
+  )
+  .daffodilProject()

--- a/src/sbt-test/sbt-daffodil/tdml-saved-parser-01/build.sbt
+++ b/src/sbt-test/sbt-daffodil/tdml-saved-parser-01/build.sbt
@@ -15,21 +15,16 @@
  * limitations under the License.
  */
 
-version := "0.1"
-
-name := "test"
-
-organization := "com.example"
-
-enablePlugins(DaffodilPlugin)
-
-daffodilPackageBinInfos := Seq(
-  DaffodilBinInfo("/com/example/test.dfdl.xsd"),
-  DaffodilBinInfo("/com/example/test.dfdl.xsd", Some("test02"), Some("two"))
-)
-
-daffodilPackageBinVersions := Seq("3.6.0", "3.5.0")
-
-daffodilVersion := daffodilPackageBinVersions.value.head
-
-daffodilTdmlUsesPackageBin := true
+val test = (project in file("."))
+  .settings(
+    version := "0.1",
+    name := "test",
+    organization := "com.example",
+    daffodilVersion := "3.6.0",
+    daffodilPackageBinInfos := Seq(
+      DaffodilBinInfo("/com/example/test.dfdl.xsd"),
+      DaffodilBinInfo("/com/example/test.dfdl.xsd", Some("test02"), Some("two"))
+    ),
+    daffodilTdmlUsesPackageBin := true,
+  )
+  .daffodilProject(crossDaffodilVersions = Seq("3.5.0"))

--- a/src/sbt-test/sbt-daffodil/tdml-saved-parser-01/test.script
+++ b/src/sbt-test/sbt-daffodil/tdml-saved-parser-01/test.script
@@ -17,9 +17,7 @@
 ## 
 
 > packageDaffodilBin
-$ exists target/test-0.1-daffodil350.bin
 $ exists target/test-0.1-daffodil360.bin
-$ exists target/test-0.1-two-daffodil350.bin
 $ exists target/test-0.1-two-daffodil360.bin
 
 > Test/compile
@@ -27,3 +25,13 @@ $ must-mirror target/test-classes/test.bin target/test-0.1-daffodil360.bin
 $ must-mirror target/test-classes/test-two.bin target/test-0.1-two-daffodil360.bin
 
 > test
+
+> test_daffodil350/packageDaffodilBin
+$ exists target/daffodil350/test-0.1-daffodil350.bin
+$ exists target/daffodil350/test-0.1-two-daffodil350.bin
+
+> test_daffodil350/Test/compile
+$ must-mirror target/daffodil350/test-classes/test.bin target/daffodil350/test-0.1-daffodil350.bin
+$ must-mirror target/daffodil350/test-classes/test-two.bin target/daffodil350/test-0.1-two-daffodil350.bin
+
+> test_daffodil350/Test/test

--- a/src/sbt-test/sbt-daffodil/versions-01/build.sbt
+++ b/src/sbt-test/sbt-daffodil/versions-01/build.sbt
@@ -15,16 +15,13 @@
  * limitations under the License.
  */
 
-version := "0.1"
-
-name := "test"
-
-organization := "com.example"
-
-enablePlugins(DaffodilPlugin)
-
-daffodilPackageBinInfos := Seq(
-  DaffodilBinInfo("/com/example/test.dfdl.xsd")
-)
-
-daffodilPackageBinVersions := Seq(daffodilVersion.value)
+val test = (project in file("."))
+  .settings(
+    version := "0.1",
+    name := "test",
+    organization := "com.example",
+    daffodilPackageBinInfos := Seq(
+      DaffodilBinInfo("/com/example/test.dfdl.xsd")
+    ),
+  )
+  .daffodilProject()


### PR DESCRIPTION
Adds a new implicitly callable .daffodilProject() function to convert a normal SBT project to one that enables the daffodil plugin and changes a number of settings to make building/test/etc. easier, including support building with multiple Daffodil versions.

Deprecation/Backwards Compatability:

We now recommend the use of the more modern SBT project definition syntax and the `.daffodilProject()` function. This adds a number of enhancements that follow best practices, and includes imporoved support for building/testing/etc. with multiple Daffodil versions. When using this function, existing settings can be used except for `daffodilProjectVersionInfos`, which is ignored if specified.

Tests are all updated to the recommended syntax, though the changes are backwards compatible so any projects using the old syntax should work exactly the same as before.

Closes #125