### PR TITLE
Ensure plugins are build with correct JDK compatability

### DIFF
--- a/src/sbt-test/sbt-daffodil/cross-versions-03/build.sbt
+++ b/src/sbt-test/sbt-daffodil/cross-versions-03/build.sbt
@@ -25,7 +25,7 @@ val plugin = (project in file("plugin"))
     daffodilVersion := "3.10.0",
     daffodilBuildsCharset := true,
   )
-  .daffodilProject(crossDaffodilVersions = Seq("3.11.0"))
+  .daffodilProject(crossDaffodilVersions = Seq("3.1.0", "3.11.0"))
 
 val schema = (project in file("schema"))
   .settings(


### PR DESCRIPTION
When building plugins, we want class files to have compatability for the minimum JDK version supported by the target daffodilVersion. This means plugins compiled with daffodilVersion 4.0.0+ will have class versions compatible with JDK 17+. All other daffodilVersions will target JDK 8.

Closes #129