### PR TITLE
Add new daffodilPlugin and daffodilBin ModuleID implicit enrichments

### DIFF
--- a/src/sbt-test/sbt-daffodil/cross-versions-03/test.script
+++ b/src/sbt-test/sbt-daffodil/cross-versions-03/test.script
@@ -29,5 +29,23 @@
 # test only 3.11.0 with the plugin
 > schema_daffodil3110/test
 
-# test only 4.0.0 with the plugin, this fails because the plugin was not build for 4.0.0
--> schema_daffodil400/test
+# test only 4.0.0 with the plugin
+> schema_daffodil400/test
+
+# publish the schema and all versions of saved parsers
+> schema/publish
+
+# run bundle resource generators, which should copy the plugin and saved
+# parsers to a "release" directory
+> bundle/package
+> bundle_daffodil3110/package
+> bundle_daffodil400/package
+
+$ exists bundle/target/release/test-plugin-0.1-daffodil400.jar
+$ exists bundle/target/release/test-schema-0.1-daffodil400.bin
+
+$ exists bundle/target/release/test-plugin-0.1-daffodil3100.jar
+$ exists bundle/target/release/test-schema-0.1-daffodil3100.bin
+
+$ exists bundle/target/release/test-plugin-0.1-daffodil3110.jar
+$ exists bundle/target/release/test-schema-0.1-daffodil3110.bin


### PR DESCRIPTION
This adds two new implicit enrichments to ModuleId, which allows projects to more easily specify dependencies to Daffodil plugins or saved parsers without needing to know the details of how to reference them (e.g. Artifacts, classifiers, types, extensions).

For example, depending on a plugin and saved parser now looks like this:

    libraryDependences ++= Seq(
      "org.example" % "dfdl-plugin" % "1.0.0" daffodilPlugin(daffodilVersion.value),
      "org.example" % "dfdl-fmt" % "1.0.0"  daffodilBin(daffodilVersion.value)
    )

This causes SBT to download the the specified plugin and saved parser, allowing for easy testing or creationg of relase bundles.

Note that this also removes the daffodilPluginDependences setting--the daffodilPlugin enrichment provides the same core functionality.

Also updates the cross-version-03 testto use the new enrichments. A new "bundle" project is added to the test to depend on saved parsers and show how to copy the plugin and parsers to a directory. This mimicks one possible way to automate creating releases of pre-compiled artifacts.

Closes #146