### PR TITLE
Ensure release builds are built on Java 17

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -56,7 +56,7 @@ jobs:
         uses: actions/setup-java@7a6d8a8234af8eb26422e24e3006232cccaa061b # v4.6.0
         with:
           distribution: temurin
-          java-version: 8
+          java-version: 17
           cache: sbt
 
       # Publish jars to a staging maven repository and write helper binary


### PR DESCRIPTION
Daffodil 4.0.0 and newer requires a minimum of Java 17 to build, so we must build on Java 17. Note that the plugin class files are built with Java 8 compatibility so the plugin still works on older versions of Java. It is only the Daffodil Saver components used when daffodilVersion is 4.0.0 or newer where the classes are built with Java 17.