### PR TITLE
Set max-parallel for all GitHub action jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,7 @@ jobs:
     name: Java ${{ matrix.java_version }}, Scala ${{ matrix.scala_version }}, ${{ matrix.os }}
     strategy:
       fail-fast: false
+      max-parallel: 5
       matrix:
         java_distribution: [ temurin ]
         java_version: [ 17, 21 ]
@@ -103,6 +104,7 @@ jobs:
     name: Lint Checks
     strategy:
       fail-fast: false
+      max-parallel: 1
       matrix:
         java_distribution: [ temurin ]
         java_version: [ 17 ]


### PR DESCRIPTION
In accordance with ASF policy, set job.strategy.max-parallel to the recommended 15 or less. Most values are set to 1, except for when there are matrices, in which case the value is set to the number of expected jobs for the matrix, with a maximum of 15.

DAFFODIL-3069