### PR TITLE
Enable `src/{main,test}/scala-XYZ` crossPath directories

### DIFF
--- a/src/sbt-test/sbt-daffodil/cross-versions-01/src/main/scala-2.12/OnlyScala212.scala
+++ b/src/sbt-test/sbt-daffodil/cross-versions-01/src/main/scala-2.12/OnlyScala212.scala
@@ -15,10 +15,9 @@
  * limitations under the License.
  */
 
-// Not an actual layer. This is only used to show plugins can include Daffodil version specific
-// files. This code should only compile on Scala 2.13 (used by Daffodil 3.11.0)
+// Not an actual layer. This is only used to show plugins can include Scala version specific
+// files. This code should only compile on Scala 2.12 (used by Daffodil 3.10.0 and older)
 
-object OnlyScala213 {
-  val l: LazyList[Int] = LazyList(1, 2, 3) // fails in Scala 2.12
-  val s = 'mySymbol // fails in Scala 3
+object OnlyScala212 {
+  val l: TraversableOnce[Int] = List(1, 2, 3)
 }

--- a/src/sbt-test/sbt-daffodil/cross-versions-01/src/main/scala-2.13/OnlyScala213.scala
+++ b/src/sbt-test/sbt-daffodil/cross-versions-01/src/main/scala-2.13/OnlyScala213.scala
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Not an actual layer. This is only used to show plugins can include Scala version specific
+// files. This code should only compile on Scala 2.13 (used by Daffodil 3.11.0)
+
+object OnlyScala213 {
+  val l: LazyList[Int] = LazyList(1, 2, 3) // fails in Scala 2.12
+  val s = 'mySymbol // fails in Scala 3
+}

--- a/src/sbt-test/sbt-daffodil/cross-versions-01/src/main/scala-3/OnlyScala3.scala
+++ b/src/sbt-test/sbt-daffodil/cross-versions-01/src/main/scala-3/OnlyScala3.scala
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Not an actual layer. This is only used to show plugins can include scala version specific
+// files. This code should only compile on Scala 3 (used by Daffodil 4.0.0 and newer)
+
+// enum is a new keyword in Scala 3
+enum OnlyScala3 {
+  case A, B, C
+}
+

--- a/src/sbt-test/sbt-daffodil/cross-versions-01/src/main/scala-daffodil-3.10.0/OnlyDaffodil3100.scala
+++ b/src/sbt-test/sbt-daffodil/cross-versions-01/src/main/scala-daffodil-3.10.0/OnlyDaffodil3100.scala
@@ -16,10 +16,8 @@
  */
 
 // Not an actual layer. This is only used to show plugins can include Daffodil version specific
-// files. This code should only compile on Scala 3 (used by Daffodil 4.0.0)
+// files. This code should only compile on Scala 2.12 (used by Daffodil 3.10.0)
 
-// enum is a new keyword in Scala 3
-enum OnlyScala3 {
-  case A, B, C
+object OnlyDaffodil3100 {
+  val l: TraversableOnce[Int] = List(1, 2, 3)
 }
-

--- a/src/sbt-test/sbt-daffodil/cross-versions-01/src/main/scala-daffodil-3.11.0/OnlyDaffodil3110.scala
+++ b/src/sbt-test/sbt-daffodil/cross-versions-01/src/main/scala-daffodil-3.11.0/OnlyDaffodil3110.scala
@@ -16,8 +16,9 @@
  */
 
 // Not an actual layer. This is only used to show plugins can include Daffodil version specific
-// files. This code should only compile on Scala 2.12 (used by Daffodil 3.10.0)
+// files. This code should only compile on Scala 2.13 (used by Daffodil 3.11.0)
 
-object OnlyScala212 {
-  val l: TraversableOnce[Int] = List(1, 2, 3)
+object OnlyDaffodil3110 {
+  val l: LazyList[Int] = LazyList(1, 2, 3) // fails in Scala 2.12
+  val s = 'mySymbol // fails in Scala 3
 }

--- a/src/sbt-test/sbt-daffodil/cross-versions-01/src/main/scala-daffodil-4.0.0/OnlyDaffodil40.scala
+++ b/src/sbt-test/sbt-daffodil/cross-versions-01/src/main/scala-daffodil-4.0.0/OnlyDaffodil40.scala
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Not an actual layer. This is only used to show plugins can include Daffodil version specific
+// files. This code should only compile on Scala 3 (used by Daffodil 4.0.0)
+
+// enum is a new keyword in Scala 3
+enum OnlyDaffodil400 {
+  case A, B, C
+}
+

--- a/src/sbt-test/sbt-daffodil/cross-versions-01/test.script
+++ b/src/sbt-test/sbt-daffodil/cross-versions-01/test.script
@@ -18,24 +18,29 @@
 
 > package
 $ exists target/test-plugin-0.1-daffodil3100.jar
+$ exists target/classes/OnlyDaffodil3100.class
 $ exists target/classes/OnlyScala212.class
 $ exists target/classes/AllScala.class
 
 $ absent target/daffodil3110/test-plugin-0.1-daffodil3110.jar
+$ absent target/daffodil3110/classes/OnlyDaffodil3110.class
 $ absent target/daffodil3110/classes/OnlyScala213.class
 $ absent target/daffodil3110/classes/AllScala.class
 
 $ absent target/daffodil400/test-plugin-0.1-daffodil400.jar
+$ absent target/daffodil400/classes/OnlyDaffodil400.class
 $ absent target/daffodil400/classes/OnlyScala3.class
 $ absent target/daffodil400/classes/AllScala.class
 
 > test_daffodil3110/package
 $ exists target/daffodil3110/test-plugin-0.1-daffodil3110.jar
+$ exists target/daffodil3110/classes/OnlyDaffodil3110.class
 $ exists target/daffodil3110/classes/OnlyScala213.class
 $ exists target/daffodil3110/classes/AllScala.class
 
 > test_daffodil400/package
 $ exists target/daffodil400/test-plugin-0.1-daffodil400.jar
+$ exists target/daffodil400/classes/OnlyDaffodil400.class
 $ exists target/daffodil400/classes/OnlyScala3.class
 $ exists target/daffodil400/classes/AllScala.class
 
@@ -44,13 +49,16 @@ $ exists target/daffodil400/classes/AllScala.class
 > package
 
 $ exists target/test-plugin-0.1-daffodil3100.jar
+$ exists target/classes/OnlyDaffodil3100.class
 $ exists target/classes/OnlyScala212.class
 $ exists target/classes/AllScala.class
 
 $ exists target/daffodil3110/test-plugin-0.1-daffodil3110.jar
+$ exists target/daffodil3110/classes/OnlyDaffodil3110.class
 $ exists target/daffodil3110/classes/OnlyScala213.class
 $ exists target/daffodil3110/classes/AllScala.class
 
 $ exists target/daffodil400/test-plugin-0.1-daffodil400.jar
+$ exists target/daffodil400/classes/OnlyDaffodil400.class
 $ exists target/daffodil400/classes/OnlyScala3.class
 $ exists target/daffodil400/classes/AllScala.class


### PR DESCRIPTION
The plugin currently adds `src/{main,test}/scala-daffodil-X.Y.Z/` directories as source directories as a way to have daffodil version specific code to support building and testing with multiple daffodil versions.

However, most of the time Daffodil differences can be generalized into Scala binary differences, so it would be more useful to use `src/{main,test}/scala-{2.12,2.13,3}/` directories. Though we currently disable those by setting `crossPaths := false`.

The intention of setting `crossPaths` to false was to remove the scala binary version compatibility versions from jars, since that information isn't needed and just adds extra complexity to jars and dependencies. To keep this behavior, but to add support for cross paths added by SBT, this instead sets `crossPaths := true` and set `crossVersions` to disabled. This also removes the scala-XYZ cross path from target directories to maintain old behavior.

Closes #161