### PR TITLE
Require Scala 2.13.16 when for Daffodil 3.11.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -74,7 +74,8 @@ lazy val plugin = (project in file("."))
     // Rat check settings
     ratExcludes := Seq(
       file(".git"),
-      file("VERSION")
+      file("VERSION"),
+      file("src/sbt-test/sbt-daffodil/versions-01/src/test/resources/com/example/input.txt")
     ),
     ratFailBinaries := true
   )
@@ -120,7 +121,13 @@ lazy val utils = (projectMatrix in file("utils"))
           )
         }
       }
-    }
+    },
+    // Do not automatically add scala-library as a dependency to the sbt-daffodil-utils jar. We
+    // expect scala-library to come from the provided Daffodil dependency. This is important
+    // because in some cases newer versions of scala-library break serialization compatability
+    // and the auto added version might be too new. When using sbt-daffodil-utils, the
+    // sbt-daffodil plugin is careful about ensuring compatability
+    autoScalaLibrary := false
   )
   .jvmPlatform(
     // We really only need Scala versions and not full ModuleIds, but using ModuleId.revision

--- a/src/sbt-test/sbt-daffodil/versions-01/src/main/resources/com/example/test.dfdl.xsd
+++ b/src/sbt-test/sbt-daffodil/versions-01/src/main/resources/com/example/test.dfdl.xsd
@@ -21,6 +21,7 @@
   xmlns:xs="http://www.w3.org/2001/XMLSchema" 
   xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
   xmlns:ex="http://example.com"
+  xmlns:fn="http://www.w3.org/2005/xpath-functions"
   targetNamespace="http://example.com"
   elementFormDefault="unqualified">
 
@@ -32,6 +33,12 @@
     </appinfo>
   </annotation>
 
-  <element name="test01" type="xs:string" dfdl:lengthKind="delimited" />
+  <element name="test01" type="xs:string" dfdl:lengthKind="delimited" dfdl:terminator="%NL;">
+    <annotation>
+      <appinfo source="http://www.ogf.org/dfdl/">
+        <dfdl:assert test="{ fn:string-length(.) gt 0 }" />
+      </appinfo>
+    </annotation>
+  </element>
 
 </schema>

--- a/src/sbt-test/sbt-daffodil/versions-01/src/test/resources/com/example/input.txt
+++ b/src/sbt-test/sbt-daffodil/versions-01/src/test/resources/com/example/input.txt
@@ -1,0 +1,1 @@
+testing

--- a/src/sbt-test/sbt-daffodil/versions-01/src/test/resources/com/example/test.tdml
+++ b/src/sbt-test/sbt-daffodil/versions-01/src/test/resources/com/example/test.tdml
@@ -24,7 +24,7 @@
 
   <parserTestCase name="test01" root="test01" model="/com/example/test.dfdl.xsd">
     <document>
-      <documentPart type="text">testing</documentPart>
+      <documentPart type="file">input.txt</documentPart>
     </document>
     <infoset>
       <dfdlInfoset>

--- a/src/sbt-test/sbt-daffodil/versions-01/test.script
+++ b/src/sbt-test/sbt-daffodil/versions-01/test.script
@@ -16,74 +16,114 @@
 ## under the License.
 ## 
 
+# Note that saved parsers are created and tested with the scalaVersion set by
+# the plugin. However, the scalaVersion can sometimes be different from the
+# actual scala-library that a version of Daffodil was built and tested with.
+# This is done intentionally to provide support for newer versions of Java, and
+# in most cases does not cause issues. But it is possible it could break
+# reloading saved parsers. So, if the plugin changes how scalaVersion is set,
+# we should uncomment the exec lines below to verify that the saved parsers
+# work with actual Daffodil releases that use possibly older scala-library
+# versions. Note that these lines are commented out because they add
+# significant time to test and really only need to be run if the scalaVersion
+# setting is updated. Note that these tests passing is not a guarantee that
+# newer Scala versions do not cause issues, but the schema used is designed to
+# detect known serialization issues.
+
 > set daffodilVersion := "4.1.0"
 > packageDaffodilBin
 $ exists target/test-0.1-daffodil410.bin
 > test
+# $ exec curl -L https://www.apache.org/dyn/closer.lua/download/daffodil/4.1.0/bin/apache-daffodil-4.1.0-bin.tgz -O --output-dir target/
+# $ exec tar -xvf target/apache-daffodil-4.1.0-bin.tgz -C target/
+# $ exec target/apache-daffodil-4.1.0-bin/bin/daffodil parse -P target/test-0.1-daffodil410.bin src/test/resources/com/example/input.txt
 > clean
 
 > set daffodilVersion := "4.0.0"
 > packageDaffodilBin
-$ exists target/test-0.1-daffodil400.bin
 > test
+# $ exec curl -L https://www.apache.org/dyn/closer.lua/download/daffodil/4.0.0/bin/apache-daffodil-4.0.0-bin.tgz -O --output-dir target/
+# $ exec tar -xvf target/apache-daffodil-4.0.0-bin.tgz -C target/
+# $ exec target/apache-daffodil-4.0.0-bin/bin/daffodil parse -P target/test-0.1-daffodil400.bin src/test/resources/com/example/input.txt
 > clean
 
 > set daffodilVersion := "3.11.0"
 > packageDaffodilBin
 $ exists target/test-0.1-daffodil3110.bin
 > test
+# $ exec curl -L https://www.apache.org/dyn/closer.lua/download/daffodil/3.11.0/bin/apache-daffodil-3.11.0-bin.tgz -O --output-dir target/
+# $ exec tar -xvf target/apache-daffodil-3.11.0-bin.tgz -C target/
+# $ exec target/apache-daffodil-3.11.0-bin/bin/daffodil parse -P target/test-0.1-daffodil3110.bin src/test/resources/com/example/input.txt
 > clean
 
 > set daffodilVersion := "3.10.0"
 > packageDaffodilBin
-$ exists target/test-0.1-daffodil3100.bin
 > test
+# $ exec curl -L https://www.apache.org/dyn/closer.lua/download/daffodil/3.10.0/bin/apache-daffodil-3.10.0-bin.tgz -O --output-dir target/
+# $ exec tar -xvf target/apache-daffodil-3.10.0-bin.tgz -C target/
+# $ exec target/apache-daffodil-3.10.0-bin/bin/daffodil parse -P target/test-0.1-daffodil3100.bin src/test/resources/com/example/input.txt
 > clean
 
 > set daffodilVersion := "3.9.0"
 > packageDaffodilBin
-$ exists target/test-0.1-daffodil390.bin
 > test
+# $ exec curl -L https://www.apache.org/dyn/closer.lua/download/daffodil/3.9.0/bin/apache-daffodil-3.9.0-bin.tgz -O --output-dir target/
+# $ exec tar -xvf target/apache-daffodil-3.9.0-bin.tgz -C target/
+# $ exec target/apache-daffodil-3.9.0-bin/bin/daffodil parse -P target/test-0.1-daffodil390.bin src/test/resources/com/example/input.txt
 > clean
 
 > set daffodilVersion := "3.8.0"
 > packageDaffodilBin
-$ exists target/test-0.1-daffodil380.bin
 > test
+# $ exec curl -L https://www.apache.org/dyn/closer.lua/download/daffodil/3.8.0/bin/apache-daffodil-3.8.0-bin.tgz -O --output-dir target/
+# $ exec tar -xvf target/apache-daffodil-3.8.0-bin.tgz -C target/
+# $ exec target/apache-daffodil-3.8.0-bin/bin/daffodil parse -P target/test-0.1-daffodil380.bin src/test/resources/com/example/input.txt
 > clean
 
 > set daffodilVersion := "3.7.0"
 > packageDaffodilBin
-$ exists target/test-0.1-daffodil370.bin
 > test
+# $ exec curl -L https://www.apache.org/dyn/closer.lua/download/daffodil/3.7.0/bin/apache-daffodil-3.7.0-bin.tgz -O --output-dir target/
+# $ exec tar -xvf target/apache-daffodil-3.7.0-bin.tgz -C target/
+# $ exec target/apache-daffodil-3.7.0-bin/bin/daffodil parse -P target/test-0.1-daffodil370.bin src/test/resources/com/example/input.txt
 > clean
 
 > set daffodilVersion := "3.6.0"
 > packageDaffodilBin
-$ exists target/test-0.1-daffodil360.bin
 > test
+# $ exec curl -L https://www.apache.org/dyn/closer.lua/download/daffodil/3.6.0/bin/apache-daffodil-3.6.0-bin.tgz -O --output-dir target/
+# $ exec tar -xvf target/apache-daffodil-3.6.0-bin.tgz -C target/
+# $ exec target/apache-daffodil-3.6.0-bin/bin/daffodil parse -P target/test-0.1-daffodil360.bin src/test/resources/com/example/input.txt
 > clean
 
 > set daffodilVersion := "3.5.0"
 > packageDaffodilBin
-$ exists target/test-0.1-daffodil350.bin
 > test
+# $ exec curl -L https://www.apache.org/dyn/closer.lua/download/daffodil/3.5.0/bin/apache-daffodil-3.5.0-bin.tgz -O --output-dir target/
+# $ exec tar -xvf target/apache-daffodil-3.5.0-bin.tgz -C target/
+# $ exec target/apache-daffodil-3.5.0-bin/bin/daffodil parse -P target/test-0.1-daffodil350.bin src/test/resources/com/example/input.txt
 > clean
 
 > set daffodilVersion := "3.4.0"
 > packageDaffodilBin
-$ exists target/test-0.1-daffodil340.bin
 > test
+# $ exec curl -L https://www.apache.org/dyn/closer.lua/download/daffodil/3.4.0/bin/apache-daffodil-3.4.0-bin.tgz -O --output-dir target/
+# $ exec tar -xvf target/apache-daffodil-3.4.0-bin.tgz -C target/
+# $ exec target/apache-daffodil-3.4.0-bin/bin/daffodil parse -P target/test-0.1-daffodil340.bin src/test/resources/com/example/input.txt
 > clean
 
 > set daffodilVersion := "3.3.0"
 > packageDaffodilBin
-$ exists target/test-0.1-daffodil330.bin
 > test
+# $ exec curl -L https://www.apache.org/dyn/closer.lua/download/daffodil/3.3.0/bin/apache-daffodil-3.3.0-bin.tgz -O --output-dir target/
+# $ exec tar -xvf target/apache-daffodil-3.3.0-bin.tgz -C target/
+# $ exec target/apache-daffodil-3.3.0-bin/bin/daffodil parse -P target/test-0.1-daffodil330.bin src/test/resources/com/example/input.txt
 > clean
 
 > set daffodilVersion := "3.2.0"
 > packageDaffodilBin
-$ exists target/test-0.1-daffodil320.bin
 > test
+# $ exec curl -L https://www.apache.org/dyn/closer.lua/download/daffodil/3.2.0/bin/apache-daffodil-3.2.0-bin.tgz -O --output-dir target/
+# $ exec tar -xvf target/apache-daffodil-3.2.0-bin.tgz -C target/
+# $ exec target/apache-daffodil-3.2.0-bin/bin/daffodil parse -P target/test-0.1-daffodil320.bin src/test/resources/com/example/input.txt
 > clean


### PR DESCRIPTION
Scala 2.13.17 breaks serialization compatablity. Daffodil 3.11.0 requires scala 2.13.16, but the plugin current sets scalaVersion to 2.13.18. The causes packageDaffodilBin to create a saved parser that cannot be used with Daffodil 3.11.0.

This issue seems to only affect Daffodil 3.11.0--all other versions of Scala/Daffodil seem to maintain saved parser compatability.

This modifies the scalaVersion to pin the scala version to 2.13.16 when Daffodil version is 3.11.0. This also modifies the sbt-daffodil-utils project to not add a dependency to scala-library, instead assuming comes from Daffodil or scalaVersion, allowing control over which libary version is used.

Update the versions-01 test to include more complexity that is known to cause issues with reloading saved parsers if built with newer versions of scala-library.

Closes #163