### PR TITLE
Add daffodil-japi/sapi as test dependencies

### DIFF
--- a/src/main/scala/org/apache/daffodil/DaffodilPlugin.scala
+++ b/src/main/scala/org/apache/daffodil/DaffodilPlugin.scala
@@ -304,6 +304,17 @@ object DaffodilPlugin extends AutoPlugin {
         ">=3.0.0 <3.2.0" -> Seq(
           "org.apache.daffodil" %% "daffodil-tdml-processor" % daffodilVersion.value % "test"
         ),
+        // It is not uncommon for projects to implement their own test harness using Daffodil
+        // APIs. This requires manually adding daffodil-japi or daffodil-sapi to
+        // libraryDependencies, and can add extra complexity to build.sbt configurations,
+        // especially when crossDaffodilVersions is used. For simplification and convenience,
+        // add those API jars as "test" dependencies. Note that we do not need to do this for
+        // Daffodil 4.0.0 and newer since their APIs are in daffodil-core which
+        // daffodil-tdml-junit (added above) transitively depends on
+        "<=3.11.0" -> Seq(
+          "org.apache.daffodil" %% "daffodil-japi" % daffodilVersion.value % "test",
+          "org.apache.daffodil" %% "daffodil-sapi" % daffodilVersion.value % "test"
+        ),
         // junit dependencies
         ">=3.0.0" -> Seq(
           "junit" % "junit" % "4.13.2" % "test",

--- a/src/sbt-test/sbt-daffodil/cross-versions-04/build.sbt
+++ b/src/sbt-test/sbt-daffodil/cross-versions-04/build.sbt
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+val test = (project in file("."))
+  .settings(
+    version := "0.1",
+    name := "test",
+    organization := "com.example",
+    daffodilVersion := "4.0.0"
+  )
+  .daffodilProject(crossDaffodilVersions = Seq("3.11.0", "3.10.0"))

--- a/src/sbt-test/sbt-daffodil/cross-versions-04/project/plugins.sbt
+++ b/src/sbt-test/sbt-daffodil/cross-versions-04/project/plugins.sbt
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+addSbtPlugin("org.apache.daffodil" % "sbt-daffodil" % sys.props("plugin.version"))

--- a/src/sbt-test/sbt-daffodil/cross-versions-04/src/test/scala-2/com/example/DaffodilAPI.scala
+++ b/src/sbt-test/sbt-daffodil/cross-versions-04/src/test/scala-2/com/example/DaffodilAPI.scala
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example
+
+object DaffodilAPI {
+  def compiler() = org.apache.daffodil.sapi.Daffodil.compiler()
+}

--- a/src/sbt-test/sbt-daffodil/cross-versions-04/src/test/scala-3/com/example/DaffodilAPI.scala
+++ b/src/sbt-test/sbt-daffodil/cross-versions-04/src/test/scala-3/com/example/DaffodilAPI.scala
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example
+
+object DaffodilAPI {
+  def compiler() = org.apache.daffodil.api.Daffodil.compiler()
+}

--- a/src/sbt-test/sbt-daffodil/cross-versions-04/src/test/scala/com/example/test.scala
+++ b/src/sbt-test/sbt-daffodil/cross-versions-04/src/test/scala/com/example/test.scala
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example
+
+import org.junit.Test
+import org.junit.Assert.assertTrue
+
+class TestExample {
+
+  @Test def test_test01(): Unit = {
+    val compiler = DaffodilAPI.compiler()
+    assertTrue(compiler.getClass.getName.contains("Compiler"))
+  }
+}

--- a/src/sbt-test/sbt-daffodil/cross-versions-04/test.script
+++ b/src/sbt-test/sbt-daffodil/cross-versions-04/test.script
@@ -1,0 +1,20 @@
+## Licensed to the Apache Software Foundation (ASF) under one
+## or more contributor license agreements.  See the NOTICE file
+## distributed with this work for additional information
+## regarding copyright ownership.  The ASF licenses this file
+## to you under the Apache License, Version 2.0 (the
+## "License"); you may not use this file except in compliance
+## with the License.  You may obtain a copy of the License at
+## 
+##  http://www.apache.org/licenses/LICENSE-2.0
+## 
+## Unless required by applicable law or agreed to in writing,
+## software distributed under the License is distributed on an
+## "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+## KIND, either express or implied.  See the License for the
+## specific language governing permissions and limitations
+## under the License.
+## 
+
+> set aggregate := true
+> test


### PR DESCRIPTION
This is useful for schema projects that implement custom test harnesses using the Daffodil public API.

Also adds a test showing the beginning of a shim layer that implements a shim layer to support multiple versions of Daffodil, and shows that japi/sapi dependencies do not need to be manually added.

Closes #168