### PR TITLE
Downgrade sbt version to 1.12.11

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -15,4 +15,4 @@
  * limitations under the License.
  */
 
-sbt.version=1.12.12
+sbt.version=1.12.11


### PR DESCRIPTION
- 1.12.12/13 is causing an acccess denied permissions error in the windows runner. Reverting back to 1.12.11 until it is fixed.