### PR TITLE
Use dynamically generated `DaffodilScalaVersions` object

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -71,6 +71,26 @@ lazy val plugin = (project in file("."))
       (Test / test).value
     },
 
+    // Generate a DaffodilScalaVersions.scala source file from the values defined in
+    // project/DaffodilScalaVersions.scala so that scala-steward can update those versions
+    // and the plugin picks them up at build time.
+    Compile / sourceGenerators += Def.task {
+      val outFile =
+        (Compile / sourceManaged).value / "org" / "apache" / "daffodil" / "DaffodilScalaVersions.scala"
+      IO.write(
+        outFile,
+        s"""package org.apache.daffodil
+           |
+           |private[daffodil] object DaffodilScalaVersions {
+           |  val scala3 = "${DaffodilScalaVersions.scala3}"
+           |  val scala213Pinned = "${DaffodilScalaVersions.scala213Pinned}"
+           |  val scala212 = "${DaffodilScalaVersions.scala212}"
+           |}
+           |""".stripMargin
+      )
+      Seq(outFile)
+    }.taskValue,
+
     // Rat check settings
     ratExcludes := Seq(
       file(".git"),

--- a/project/DaffodilScalaVersions.scala
+++ b/project/DaffodilScalaVersions.scala
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import sbt._
+
+// Scala versions to use for each supported Daffodil version range. Defined here in project/
+// so scala-steward can detect and update them. A sourceGenerators task in build.sbt embeds
+// these version strings into the compiled plugin.
+//
+// We use full ModuleIds rather than plain strings so scala-steward can detect and update the
+// versions. The .revision call extracts just the version string at build time.
+//
+// If we update one of the below scala-library versions, we should verify that official
+// Daffodil releases using older versions of scala-library can still reload saved parsers built
+// with this newer scalaVersion (see the comment in DaffodilPlugin.scala for details). See the
+// versions-01 scripted test for how to manually verify this.
+object DaffodilScalaVersions {
+  val scala3 = ("org.scala-lang" % "scala3-library" % "3.3.7").revision
+  // scala-steward:off
+  val scala213Pinned = ("org.scala-lang" % "scala-library" % "2.13.16").revision
+  // scala-steward:on
+  val scala212 = ("org.scala-lang" % "scala-library" % "2.12.21").revision
+}

--- a/src/main/scala/org/apache/daffodil/DaffodilPlugin.scala
+++ b/src/main/scala/org/apache/daffodil/DaffodilPlugin.scala
@@ -258,18 +258,13 @@ object DaffodilPlugin extends AutoPlugin {
      * to the working version, which may limit JDK support.
      */
     scalaVersion := {
-      // We really only need Scala versions and not full ModuleIds, but using ModuleId.revision
-      // makes it easier for scala-steward to detect and automatically update the versions when
-      // new Scala patch versions are released.
-      //
-      // Note that if we update one of the below scala-library versions, we should verify that
-      // official Daffodil releases using older versions of scala-library can still reload saved
-      // parsers built with this newer scalaVersion (see above note about serialization
-      // compatibility). See the versions-01 scripted test to how to manually verify this.
+      // Scala versions are defined in project/DaffodilScalaVersions.scala so that
+      // scala-steward can detect and update them. A sourceGenerators task in build.sbt
+      // embeds those version strings into DaffodilScalaVersions at compile time.
       val daffodilToScalaVersion = Map(
-        ">=4.0.0 " -> ("org.scala-lang" % "scala3-library" % "3.3.7").revision,
-        "=3.11.0 " -> ("org.scala-lang" % "scala-library" % "2.13.16").revision, // scala-steward:off
-        "<=3.10.0" -> ("org.scala-lang" % "scala-library" % "2.12.21").revision
+        ">=4.0.0 " -> DaffodilScalaVersions.scala3,
+        "=3.11.0 " -> DaffodilScalaVersions.scala213Pinned,
+        "<=3.10.0" -> DaffodilScalaVersions.scala212
       )
       filterVersions(daffodilVersion.value, daffodilToScalaVersion).head
     },


### PR DESCRIPTION
- This is so scala-steward can pick up on and update the non-pinned versions